### PR TITLE
Fix 2031

### DIFF
--- a/zds/article/views.py
+++ b/zds/article/views.py
@@ -716,7 +716,7 @@ def modify(request):
                 article.slug
             ])
 
-            author_username = request.POST['author']
+            author_username = request.POST['author'].strip()
             author = None
             try:
                 author = User.objects.get(username=author_username)

--- a/zds/article/views.py
+++ b/zds/article/views.py
@@ -723,7 +723,7 @@ def modify(request):
                 if author.profile.is_private():
                     raise User.DoesNotExist
             except User.DoesNotExist:
-                messages.error(request, "Utilisateur inexistant ou introuvable.")
+                messages.error(request, u'Utilisateur inexistant ou introuvable.')
                 return redirect(redirect_url)
 
             article.authors.add(author)

--- a/zds/tutorial/views.py
+++ b/zds/tutorial/views.py
@@ -570,13 +570,14 @@ def modify_tutorial(request):
                 tutorial.pk,
                 tutorial.slug,
             ])
-            author_username = request.POST["author"]
+            author_username = request.POST["author"].strip()
             author = None
             try:
                 author = User.objects.get(username=author_username)
                 if author.profile.is_private():
                     raise User.DoesNotExist
             except User.DoesNotExist:
+                messages.error(request, "Utilisateur inexistant ou introuvable.")
                 return redirect(redirect_url)
             tutorial.authors.add(author)
             tutorial.save()

--- a/zds/tutorial/views.py
+++ b/zds/tutorial/views.py
@@ -577,7 +577,7 @@ def modify_tutorial(request):
                 if author.profile.is_private():
                     raise User.DoesNotExist
             except User.DoesNotExist:
-                messages.error(request, "Utilisateur inexistant ou introuvable.")
+                messages.error(request, _(u'Utilisateur inexistant ou introuvable.'))
                 return redirect(redirect_url)
             tutorial.authors.add(author)
             tutorial.save()


### PR DESCRIPTION
- Ajout message d'erreur lorsque le pseudo n'existe pas lors de l'ajout d'un auteur à un tuto
- Trim du pseudo pour l'ajout d'un auteur à un article ou un tuto
- Ajout de l'encodage des chaines de caractères

Côté tuto, les chaînes de caractères ont _(), ce qu'elles n'ont pas côté article. C'est par rapport à la traduction en cours ou rien à voir ? Faut faire quelque chose de particulier ?
