### PR TITLE
Création de mixins

### DIFF
--- a/templates/tutorialv2/view/diff.html
+++ b/templates/tutorialv2/view/diff.html
@@ -1,0 +1,67 @@
+{% extends "tutorialv2/base.html" %}
+{% load emarkdown %}
+{% load repo_reader %}
+{% load thumbnail %}
+{% load i18n %}
+
+
+{% block title %}
+    {{ content.title }}
+{% endblock %}
+
+
+
+{% block breadcrumb %}
+    <li><a href="{{ content.get_absolute_url }}">{{ content.title }}</a></li>
+    <li><a href="{% url "content:history" content.pk content.slug %}">{% trans "Historique des modifications" %}</a></li>
+    <li>{%  trans "Différence avec la dernière version" %}</li>
+{% endblock %}
+
+
+
+{# No sidebar on this page #}
+{% block body_class %}no-sidebar{% endblock %}
+{% block sidebar %}{% endblock %}
+
+
+
+{% block headline %}
+    <h1 {% if content.image %}class="illu"{% endif %}>
+        {% if content.image %}
+            <img src="{{content.image.physical.tutorial_illu.url }}" alt="">
+        {% endif %}
+        {{ content.title }}
+    </h1>
+
+    {% include 'tutorialv2/includes/tags_authors.part.html' %}
+{% endblock %}
+
+
+
+{% block content_ext %}
+    <p>
+    <b>Message de commit :</b> {{ commit_msg }}
+    </p>
+
+    <h2>{% trans "Nouveaux Fichiers" %}</h2>
+    {% for add in path_add %}
+        {% with add_next=add.b_blob|repo_blob %}
+            <h3>{{ add.b_blob.path }}</h3>
+            <div class="diff_delta">
+                {{ ''|diff_text:add_next|safe }}
+            </div>
+        {% endwith %}
+    {% endfor %}
+
+    <h2>{% trans "Fichiers Modifiés" %}</h2>
+    {% for maj in path_maj %}
+        {% with maj_next=maj.b_blob|repo_blob %}
+            {% with maj_prev=maj.a_blob|repo_blob %}
+                <h3>{{ maj.a_blob.path }}</h3>
+                <div class="diff_delta">
+                    {{ maj_prev|diff_text:maj_next|safe }}
+                </div>
+            {% endwith %}
+        {% endwith %}
+    {% endfor %}
+{% endblock %}

--- a/templates/tutorialv2/view/history.html
+++ b/templates/tutorialv2/view/history.html
@@ -78,7 +78,7 @@
                         </a>
                     </td>
                     <td>
-                        <a href="{% url "zds.tutorial.views.diff" content.pk content.slug %}?sha={{ log.newhexsha }}" >
+                        <a href="{% url "content:diff" content.pk content.slug %}?version={{ log.newhexsha }}" >
                             {{ log.newhexsha|truncatechars:8 }}
                         </a>
                     </td>

--- a/zds/tutorialv2/factories.py
+++ b/zds/tutorialv2/factories.py
@@ -166,8 +166,8 @@ class ValidationFactory(factory.DjangoModelFactory):
 class LicenceFactory(factory.DjangoModelFactory):
     FACTORY_FOR = Licence
 
-    code = u'Licence bidon'
-    title = u'Licence bidon'
+    code = factory.Sequence(lambda n: 'bidon-no{0}'.format(n + 1))
+    title = factory.Sequence(lambda n: 'Licence bidon no{0}'.format(n + 1))
 
     @classmethod
     def _prepare(cls, create, **kwargs):

--- a/zds/tutorialv2/mixins.py
+++ b/zds/tutorialv2/mixins.py
@@ -1,0 +1,148 @@
+from django.http import Http404
+from django.core.exceptions import PermissionDenied
+from django.shortcuts import get_object_or_404
+from django.views.generic import DetailView, FormView
+from zds.tutorialv2.models import PublishableContent
+
+
+class SingleContentViewMixin(object):
+    """
+    Base mixin to get only one content, and its corresponding versioned content
+    sends 404 error if the primary key is not found or the slug is not coherent,
+    sends 403 error if the view is only accessible for author
+    """
+
+    must_be_author = True
+    authorized_for_staff = True
+    prefetch_all = True
+
+    only_draft_version = True
+    sha = None
+
+    def get_object(self, queryset=None):
+        if self.prefetch_all:
+            queryset = PublishableContent.objects \
+                .select_related("licence") \
+                .prefetch_related("authors") \
+                .prefetch_related("subcategory") \
+                .filter(pk=self.kwargs["pk"])
+
+            obj = queryset.first()
+        else:
+            obj = get_object_or_404(PublishableContent, pk=self.kwargs['pk'])
+        if 'slug' in self.kwargs and obj.slug != self.kwargs['slug']:
+            raise Http404
+        if self.must_be_author and self.request.user not in obj.authors.all():
+            if self.authorized_for_staff and self.request.user.has_perm('tutorial.change_tutorial'):
+                return obj
+            raise PermissionDenied
+        return obj
+
+    def get_versioned_object(self):
+        sha = self.object.sha_draft
+
+        if not self.only_draft_version:
+            if self.sha:
+                sha = self.sha
+            else:
+                try:
+                    sha = self.request.GET["version"]
+                except KeyError:
+                    pass
+
+        # if beta, user can also access to it
+        is_beta = self.object.is_beta(sha)
+        if self.request.user not in self.object.authors.all() and not is_beta:
+            if not self.request.user.has_perm("tutorial.change_tutorial"):
+                raise PermissionDenied
+
+        # load versioned file
+        return self.object.load_version_or_404(sha)
+
+
+class SingleContentPostMixin(SingleContentViewMixin):
+    """
+    Base mixin used to get content from post query
+    """
+    # represent the fact that we have to check if the version given in self.request.POST['version'] exists
+    versioned = True
+
+    def get_object(self, queryset=None):
+        try:
+            self.kwargs["pk"] = self.request.POST['pk']
+        except KeyError:
+            raise Http404
+        obj = super(SingleContentPostMixin, self).get_object()
+        if self.versioned and 'version' in self.request.POST['version']:
+            obj.load_version_or_404(sha=self.request.POST['version'])
+        return obj
+
+
+class SingleContentFormViewMixin(SingleContentViewMixin, FormView):
+    """
+    This enhanced FormView ensure,
+
+    - by surcharging `dispatch()`, that:
+        * `self.object` contains the result of `get_object()` (as for DetailView)
+        * `self.versioned_object` contains the results of `get_versioned_object()`
+    - by surcharging `get_context_data()`, that
+        * context['content'] contains `self.versioned_object`
+    """
+
+    object = None
+    versioned_object = None
+
+    def dispatch(self, request, *args, **kwargs):
+        self.object = self.get_object()
+        self.versioned_object = self.get_versioned_object()
+
+        return super(SingleContentFormViewMixin, self).dispatch(request, *args, **kwargs)
+
+    def get_context_data(self, **kwargs):
+        context = super(SingleContentFormViewMixin, self).get_context_data(**kwargs)
+        context['content'] = self.versioned_object
+
+        return context
+
+
+class SingleContentDetailViewMixin(SingleContentViewMixin, DetailView):
+    """
+    This enhanced DetailView ensure,
+
+    - by rewriting `get()`, that:
+        * `self.object` contains the result of `get_object()` (as it must be if `get()` is not rewritten)
+        * `self.sha` is set according to `self.request.GET['version']` (if any) and `self.object.sha_draft` otherwise
+        * `self.versioned_object` contains the results of `get_versioned_object()`
+    - by surcharging `get_context_data()`, that
+        * context['content'] contains `self.versioned_object`
+        * context['can_edit'] is set
+        * context['version'] is set (if different from `self.object.sha_draft`)
+    """
+
+    object = None
+    versioned_object = None
+
+    def get(self, request, *args, **kwargs):
+        self.object = self.get_object()
+
+        if not self.sha:
+            try:
+                self.sha = request.GET["version"]
+            except KeyError:
+                self.sha = self.object.sha_draft
+
+        self.versioned_object = self.get_versioned_object()
+
+        context = self.get_context_data(object=self.object)
+        return self.render_to_response(context)
+
+    def get_context_data(self, **kwargs):
+        context = super(SingleContentDetailViewMixin, self).get_context_data(**kwargs)
+
+        context['content'] = self.versioned_object
+        context['can_edit'] = self.request.user in self.object.authors.all()
+
+        if self.sha != self.object.sha_draft:
+            context["version"] = self.sha
+
+        return context

--- a/zds/tutorialv2/models.py
+++ b/zds/tutorialv2/models.py
@@ -344,7 +344,7 @@ class Container:
             self.title = title
             if self.get_tree_depth() > 0:  # if top container, slug is generated from DB, so already changed
                 old_path = self.get_path(relative=True)
-                self.slug = self.top_container().get_unique_slug(title)
+                self.slug = self.parent.get_unique_slug(title)
                 new_path = self.get_path(relative=True)
                 repo.index.move([old_path, new_path])
 
@@ -472,12 +472,12 @@ class Container:
 
         # now, remove from manifest
         # work only if slug is correct
-        top = self.top_container()
+        top = self.parent
         top.children_dict.pop(self.slug)
         top.children.pop(top.children.index(self))
 
         # commit
-        top.dump_json()
+        top.top_container().dump_json()
         repo.index.add(['manifest.json'])
 
         if commit_message == '':

--- a/zds/tutorialv2/tests/tests_views.py
+++ b/zds/tutorialv2/tests/tests_views.py
@@ -10,7 +10,8 @@ from django.core.urlresolvers import reverse
 
 from zds.settings import SITE_ROOT
 from zds.member.factories import ProfileFactory, StaffProfileFactory
-from zds.tutorialv2.factories import PublishableContentFactory, ContainerFactory, ExtractFactory, LicenceFactory
+from zds.tutorialv2.factories import PublishableContentFactory, ContainerFactory, ExtractFactory, LicenceFactory, \
+    SubCategoryFactory
 from zds.tutorialv2.models import PublishableContent
 from zds.gallery.factories import GalleryFactory
 
@@ -29,9 +30,11 @@ class ContentTests(TestCase):
         settings.ZDS_APP['member']['bot_account'] = self.mas.username
 
         self.licence = LicenceFactory()
+        self.subcategory = SubCategoryFactory()
 
         self.user_author = ProfileFactory().user
         self.staff = StaffProfileFactory().user
+        self.guest = ProfileFactory().user
 
         self.tuto = PublishableContentFactory(type='TUTORIAL')
         self.tuto.authors.add(self.user_author)
@@ -46,6 +49,8 @@ class ContentTests(TestCase):
         self.extract1 = ExtractFactory(container=self.chapter1, db_object=self.tuto)
 
     def test_ensure_access(self):
+        """General access test for author, user, guest and staff"""
+
         # login with author
         self.assertEqual(
             self.client.login(
@@ -55,19 +60,97 @@ class ContentTests(TestCase):
 
         tuto = PublishableContent.objects.get(pk=self.tuto.pk)
 
-        # check access for user
+        # check access for author (get 200, for content, part, chapter)
         result = self.client.get(
             reverse('content:view', args=[tuto.pk, tuto.slug]),
             follow=False)
         self.assertEqual(result.status_code, 200)
 
+        result = self.client.get(
+            reverse('content:view-container',
+                    kwargs={
+                        'pk': tuto.pk,
+                        'slug': tuto.slug,
+                        'container_slug': self.part1.slug
+                    }),
+            follow=False)
+        self.assertEqual(result.status_code, 200)
+
+        result = self.client.get(
+            reverse('content:view-container',
+                    kwargs={
+                        'pk': tuto.pk,
+                        'slug': tuto.slug,
+                        'parent_container_slug': self.part1.slug,
+                        'container_slug': self.chapter1.slug
+                    }),
+            follow=False)
+        self.assertEqual(result.status_code, 200)
+
         self.client.logout()
 
-        # check access for public (get 302, login)
+        # check access for public (get 302, for content, part, chapter)
         result = self.client.get(
             reverse('content:view', args=[tuto.pk, tuto.slug]),
             follow=False)
         self.assertEqual(result.status_code, 302)
+
+        result = self.client.get(
+            reverse('content:view-container',
+                    kwargs={
+                        'pk': tuto.pk,
+                        'slug': tuto.slug,
+                        'container_slug': self.part1.slug
+                    }),
+            follow=False)
+        self.assertEqual(result.status_code, 302)
+
+        result = self.client.get(
+            reverse('content:view-container',
+                    kwargs={
+                        'pk': tuto.pk,
+                        'slug': tuto.slug,
+                        'parent_container_slug': self.part1.slug,
+                        'container_slug': self.chapter1.slug
+                    }),
+            follow=False)
+        self.assertEqual(result.status_code, 302)
+
+        # login with guest
+        self.assertEqual(
+            self.client.login(
+                username=self.guest.username,
+                password='hostel77'),
+            True)
+
+        tuto = PublishableContent.objects.get(pk=self.tuto.pk)
+
+        # check access for guest (get 403 for content, part and chapter, since he is not part of the authors)
+        result = self.client.get(
+            reverse('content:view', args=[tuto.pk, tuto.slug]),
+            follow=False)
+        self.assertEqual(result.status_code, 403)
+
+        result = self.client.get(
+            reverse('content:view-container',
+                    kwargs={
+                        'pk': tuto.pk,
+                        'slug': tuto.slug,
+                        'container_slug': self.part1.slug
+                    }),
+            follow=False)
+        self.assertEqual(result.status_code, 403)
+
+        result = self.client.get(
+            reverse('content:view-container',
+                    kwargs={
+                        'pk': tuto.pk,
+                        'slug': tuto.slug,
+                        'parent_container_slug': self.part1.slug,
+                        'container_slug': self.chapter1.slug
+                    }),
+            follow=False)
+        self.assertEqual(result.status_code, 403)
 
         # login with staff
         self.assertEqual(
@@ -78,14 +161,35 @@ class ContentTests(TestCase):
 
         tuto = PublishableContent.objects.get(pk=self.tuto.pk)
 
-        # check access for staff (get 200)
+        # check access for staff (get 200 for content, part and chapter)
         result = self.client.get(
             reverse('content:view', args=[tuto.pk, tuto.slug]),
             follow=False)
         self.assertEqual(result.status_code, 200)
 
-    def test_deletion(self):
-        """Ensure deletion behavior"""
+        result = self.client.get(
+            reverse('content:view-container',
+                    kwargs={
+                        'pk': tuto.pk,
+                        'slug': tuto.slug,
+                        'container_slug': self.part1.slug
+                    }),
+            follow=False)
+        self.assertEqual(result.status_code, 200)
+
+        result = self.client.get(
+            reverse('content:view-container',
+                    kwargs={
+                        'pk': tuto.pk,
+                        'slug': tuto.slug,
+                        'parent_container_slug': self.part1.slug,
+                        'container_slug': self.chapter1.slug
+                    }),
+            follow=False)
+        self.assertEqual(result.status_code, 200)
+
+    def test_basic_tutorial_workflow(self):
+        """General test on the basic workflow of a tutorial: creation, edition, deletion for the author"""
 
         # login with author
         self.assertEqual(
@@ -94,28 +198,287 @@ class ContentTests(TestCase):
                 password='hostel77'),
             True)
 
-        # create a new tutorial
-        tuto = PublishableContentFactory(type='TUTORIAL')
-        tuto.authors.add(self.user_author)
-        tuto.gallery = GalleryFactory()
-        tuto.licence = self.licence
-        tuto.save()
-
-        versioned = tuto.load_version()
-        path = versioned.get_path()
-
-        # delete it
-        result = self.client.get(
-            reverse('content:delete', args=[tuto.pk, tuto.slug]),
-            follow=True)
-        self.assertEqual(result.status_code, 405)  # get method is not allowed for deleting
+        # create tutorial
+        intro = u'une intro'
+        conclusion = u'une conclusion'
+        description = u'une description'
+        title = u'un titre'
+        random = u'un truc à la rien à voir'
 
         result = self.client.post(
-            reverse('content:delete', args=[tuto.pk, tuto.slug]),
+            reverse('content:create'),
+            {
+                'title': title,
+                'description': description,
+                'introduction': intro,
+                'conclusion': conclusion,
+                'type': u'TUTORIAL',
+                'licence': self.licence.pk,
+                'subcategory': self.subcategory.pk,
+            },
+            follow=False)
+        self.assertEqual(result.status_code, 302)
+        self.assertEqual(PublishableContent.objects.all().count(), 2)
+
+        tuto = PublishableContent.objects.last()
+        pk = tuto.pk
+        slug = tuto.slug
+
+        # access to tutorial
+        result = self.client.get(
+            reverse('content:edit', args=[pk, slug]),
+            follow=False)
+        self.assertEqual(result.status_code, 200)
+
+        # edit tutorial:
+        new_licence = LicenceFactory()
+
+        result = self.client.post(
+            reverse('content:edit', args=[pk, slug]),
+            {
+                'title': random,
+                'description': random,
+                'introduction': random,
+                'conclusion': random,
+                'type': u'TUTORIAL',
+                'licence': new_licence.pk,
+                'subcategory': self.subcategory.pk,
+            },
             follow=False)
         self.assertEqual(result.status_code, 302)
 
-        self.assertFalse(os.path.isfile(path))  # deletion get right ;)
+        tuto = PublishableContent.objects.get(pk=pk)
+        self.assertEqual(tuto.title, random)
+        self.assertEqual(tuto.description, random)
+        self.assertEqual(tuto.licence.pk, new_licence.pk)
+        versioned = tuto.load_version()
+        self.assertEqual(versioned.get_introduction(), random)
+        self.assertEqual(versioned.get_conclusion(), random)
+        self.assertEqual(versioned.description, random)
+        self.assertEqual(versioned.licence.pk, new_licence.pk)
+
+        slug = tuto.slug  # make the title change also change the slug !!
+
+        # create container:
+        result = self.client.post(
+            reverse('content:create-container', args=[pk, slug]),
+            {
+                'title': title,
+                'introduction': intro,
+                'conclusion': conclusion
+            },
+            follow=False)
+        self.assertEqual(result.status_code, 302)
+
+        versioned = PublishableContent.objects.get(pk=pk).load_version()
+        self.assertEqual(len(versioned.children), 1)  # ok, the container is created
+        container = versioned.children[0]
+        self.assertEqual(container.title, title)
+        self.assertEqual(container.get_introduction(), intro)
+        self.assertEqual(container.get_conclusion(), conclusion)
+
+        # access container:
+        result = self.client.get(
+            reverse('content:view-container', kwargs={'pk': pk, 'slug': slug, 'container_slug': container.slug}),
+            follow=False)
+        self.assertEqual(result.status_code, 200)
+
+        # edit container:
+        result = self.client.post(
+            reverse('content:edit-container', kwargs={'pk': pk, 'slug': slug, 'container_slug': container.slug}),
+            {
+                'title': random,
+                'introduction': random,
+                'conclusion': random
+            },
+            follow=False)
+        self.assertEqual(result.status_code, 302)
+
+        versioned = PublishableContent.objects.get(pk=pk).load_version()
+        container = versioned.children[0]
+        self.assertEqual(container.title, random)
+        self.assertEqual(container.get_introduction(), random)
+        self.assertEqual(container.get_conclusion(), random)
+
+        # add a subcontainer
+        result = self.client.post(
+            reverse('content:create-container', kwargs={'pk': pk, 'slug': slug, 'container_slug': container.slug}),
+            {
+                'title': title,
+                'introduction': intro,
+                'conclusion': conclusion
+            },
+            follow=False)
+        self.assertEqual(result.status_code, 302)
+
+        versioned = PublishableContent.objects.get(pk=pk).load_version()
+        self.assertEqual(len(versioned.children[0].children), 1)  # the subcontainer is created
+        subcontainer = versioned.children[0].children[0]
+        self.assertEqual(subcontainer.title, title)
+        self.assertEqual(subcontainer.get_introduction(), intro)
+        self.assertEqual(subcontainer.get_conclusion(), conclusion)
+
+        # access the subcontainer
+        result = self.client.get(
+            reverse('content:view-container',
+                    kwargs={
+                        'pk': pk,
+                        'slug': slug,
+                        'parent_container_slug': container.slug,
+                        'container_slug': subcontainer.slug
+                    }),
+            follow=False)
+        self.assertEqual(result.status_code, 200)
+
+        # edit subcontainer:
+        result = self.client.post(
+            reverse('content:edit-container',
+                    kwargs={
+                        'pk': pk,
+                        'slug': slug,
+                        'parent_container_slug': container.slug,
+                        'container_slug': subcontainer.slug
+                    }),
+            {
+                'title': random,
+                'introduction': random,
+                'conclusion': random
+            },
+            follow=False)
+        self.assertEqual(result.status_code, 302)
+
+        versioned = PublishableContent.objects.get(pk=pk).load_version()
+        subcontainer = versioned.children[0].children[0]
+        self.assertEqual(subcontainer.title, random)
+        self.assertEqual(subcontainer.get_introduction(), random)
+        self.assertEqual(subcontainer.get_conclusion(), random)
+
+        # add extract to subcontainer:
+        result = self.client.post(
+            reverse('content:create-extract',
+                    kwargs={
+                        'pk': pk,
+                        'slug': slug,
+                        'parent_container_slug': container.slug,
+                        'container_slug': subcontainer.slug
+                    }),
+            {
+                'title': title,
+                'text': description
+            },
+            follow=False)
+        self.assertEqual(result.status_code, 302)
+
+        versioned = PublishableContent.objects.get(pk=pk).load_version()
+        self.assertEqual(len(versioned.children[0].children[0].children), 1)  # the extract is created
+        extract = versioned.children[0].children[0].children[0]
+        self.assertEqual(extract.title, title)
+        self.assertEqual(extract.get_text(), description)
+
+        # access the subcontainer again (with the extract)
+        result = self.client.get(
+            reverse('content:view-container',
+                    kwargs={
+                        'pk': pk,
+                        'slug': slug,
+                        'parent_container_slug': container.slug,
+                        'container_slug': subcontainer.slug
+                    }),
+            follow=False)
+        self.assertEqual(result.status_code, 200)
+
+        # edit extract:
+        result = self.client.post(
+            reverse('content:edit-extract',
+                    kwargs={
+                        'pk': pk,
+                        'slug': slug,
+                        'parent_container_slug': container.slug,
+                        'container_slug': subcontainer.slug,
+                        'extract_slug': extract.slug
+                    }),
+            {
+                'title': random,
+                'text': random
+            },
+            follow=False)
+        self.assertEqual(result.status_code, 302)
+
+        versioned = PublishableContent.objects.get(pk=pk).load_version()
+        extract = versioned.children[0].children[0].children[0]
+        self.assertEqual(extract.title, random)
+        self.assertEqual(extract.get_text(), random)
+
+        # then, delete extract:
+        result = self.client.get(
+            reverse('content:delete',
+                    kwargs={
+                        'pk': pk,
+                        'slug': slug,
+                        'parent_container_slug': container.slug,
+                        'container_slug': subcontainer.slug,
+                        'object_slug': extract.slug
+                    }),
+            follow=False)
+        self.assertEqual(result.status_code, 405)  # it is not working with get !
+
+        versioned = PublishableContent.objects.get(pk=pk).load_version()
+        self.assertEqual(len(versioned.children[0].children[0].children), 1)  # and the extract still exists
+
+        result = self.client.post(
+            reverse('content:delete',
+                    kwargs={
+                        'pk': pk,
+                        'slug': slug,
+                        'parent_container_slug': container.slug,
+                        'container_slug': subcontainer.slug,
+                        'object_slug': extract.slug
+                    }),
+            follow=False)
+        self.assertEqual(result.status_code, 302)
+
+        versioned = PublishableContent.objects.get(pk=pk).load_version()
+        self.assertEqual(len(versioned.children[0].children[0].children), 0)  # extract was deleted
+        self.assertFalse(os.path.exists(extract.get_path()))  # and physically deleted as well
+
+        # delete subcontainer:
+        result = self.client.post(
+            reverse('content:delete',
+                    kwargs={
+                        'pk': pk,
+                        'slug': slug,
+                        'container_slug': container.slug,
+                        'object_slug': subcontainer.slug
+                    }),
+            follow=False)
+        self.assertEqual(result.status_code, 302)
+
+        versioned = PublishableContent.objects.get(pk=pk).load_version()
+        self.assertEqual(len(versioned.children[0].children), 0)  # subcontainer was deleted
+        self.assertFalse(os.path.exists(subcontainer.get_path()))
+
+        # delete container:
+        result = self.client.post(
+            reverse('content:delete',
+                    kwargs={
+                        'pk': pk,
+                        'slug': slug,
+                        'object_slug': container.slug
+                    }),
+            follow=False)
+        self.assertEqual(result.status_code, 302)
+
+        versioned = PublishableContent.objects.get(pk=pk).load_version()
+        self.assertEqual(len(versioned.children), 0)  # container was deleted
+        self.assertFalse(os.path.exists(container.get_path()))
+
+        # and delete tutorial itself
+        result = self.client.post(
+            reverse('content:delete', args=[pk, slug]),
+            follow=False)
+        self.assertEqual(result.status_code, 302)
+
+        self.assertFalse(os.path.isfile(versioned.get_path()))  # deletion get right ;)
 
     def tearDown(self):
         if os.path.isdir(settings.ZDS_APP['content']['repo_private_path']):

--- a/zds/tutorialv2/url/url_contents.py
+++ b/zds/tutorialv2/url/url_contents.py
@@ -4,8 +4,8 @@ from django.conf.urls import patterns, url
 
 from zds.tutorialv2.views import ListContent, DisplayContent, CreateContent, EditContent, DeleteContent,\
     CreateContainer, DisplayContainer, EditContainer, CreateExtract, EditExtract, DeleteContainerOrExtract, \
-    PutContentOnBeta, DisplayHistory, ValidationListView, ActivateJSFiddleInContent, AskValidationForContent, \
-    ReserveValidation, HistoryOfValidationDisplay
+    PutContentOnBeta, DisplayHistory, DisplayDiff, ValidationListView, ActivateJSFiddleInContent, \
+    AskValidationForContent, ReserveValidation, HistoryOfValidationDisplay
 from zds.tutorialv2.importation import ImportMarkdownView
 
 urlpatterns = patterns('',
@@ -64,7 +64,9 @@ urlpatterns = patterns('',
                            name='edit-extract'),
 
                        url(r'^editer/(?P<pk>\d+)/(?P<slug>.+)/$', EditContent.as_view(), name='edit'),
+
                        url(r'^historique/(?P<pk>\d+)/(?P<slug>.+)/$', DisplayHistory.as_view(), name="history"),
+                       url(r'^comparaison/(?P<pk>\d+)/(?P<slug>.+)/$', DisplayDiff.as_view(), name="diff"),
                        # beta
 
                        url(r'^mettre-beta/(?P<pk>\d+)/(?P<slug>.+)/$', PutContentOnBeta.as_view(), name="put-beta"),

--- a/zds/tutorialv2/utils.py
+++ b/zds/tutorialv2/utils.py
@@ -1,7 +1,7 @@
 # coding: utf-8
 from django.http import Http404
 
-from zds.tutorialv2.models import PublishableContent, ContentRead, Container
+from zds.tutorialv2.models import PublishableContent, ContentRead, Container, Extract
 from zds import settings
 from zds.utils import get_current_user
 
@@ -41,6 +41,29 @@ def search_container_or_404(base_content, kwargs_array):
     if container is None:
         raise Http404
     return container
+
+
+def search_extract_or_404(base_content, kwargs_array):
+    """
+    :param base_content: the base Publishable content we will use to retrieve the container
+    :param kwargs_array: an array that may contain `parent_container_slug` and `container_slug` and MUST contains
+    `extract_slug`
+    :return: the Extract object
+    :raise: Http404 if not found
+    """
+    # if the extract is at a depth of 3 we get the first parent container
+    container = search_container_or_404(base_content, kwargs_array)
+
+    extract = None
+    if 'extract_slug' in kwargs_array:
+        try:
+            extract = container.children_dict[kwargs_array['extract_slug']]
+        except KeyError:
+            raise Http404
+        else:
+            if not isinstance(extract, Extract):
+                raise Http404
+    return extract
 
 
 def get_last_tutorials():


### PR DESCRIPTION
Comme j'avais, dit, j'ai un peu poussé mon raisonement et j'ai trouvé, je crois, des trucs à surcharger pour avoir la même chose partout. Dès lors, deux nouveaux _mixins_ font leur apparition : 
- `SingleContentDetailViewMixin` pour les `DetailView` qui affichent les contenus et conteneurs.
- `SingleContentFormViewMixin` pour les `FormView` qui permettent de créer et modifier les contenus, conteneurs et extraits

Et j'ai tout retapé dans `zds/tutorialv2/mixins.py`, je trouvais ça plus propre.

**À NE PAS MERGER TOUT DE SUITE**, je vais me faire violence pour faire un beau T.U.

(et du coup, je suis bon pour un énorme rebase de ma branche qui faisait de l'import/export)
