### PR TITLE
Navigation à travers les âges

### DIFF
--- a/templates/tutorialv2/includes/child.part.html
+++ b/templates/tutorialv2/includes/child.part.html
@@ -3,7 +3,13 @@
 
 
 <h2 id="{{ child.position_in_parent }}-{{ child.slug }}">
-    <a href="{{ child.get_absolute_url }}{% if version %}?version={{ version }}{% endif %}">
+    <a
+    {%  if child.text %}
+        href="{{ child.container.get_absolute_url }}{% if version %}?version={{ version }}{% endif %}#{{ child.position_in_parent }}-{{ child.slug }}"
+    {% else %}
+        href="{{ child.get_absolute_url }}{% if version %}?version={{ version }}{% endif %}"
+    {% endif %}
+    >
         {{ child.title }}
     </a>
 </h2>

--- a/templates/tutorialv2/includes/summary.part.html
+++ b/templates/tutorialv2/includes/summary.part.html
@@ -48,7 +48,12 @@
                             {% if online %}
                                 href="{{ subchild.get_absolute_url_online }}"
                             {% else %}
-                                href="{{ subchild.get_absolute_url }}{% if version %}?version={{ version }}{% endif %}"
+                                {%  if subchild.text %}
+                                    {# subchild is an extract #}
+                                    href="{{ subchild.container.get_absolute_url }}{% if version %}?version={{ version }}{% endif %}#{{ subchild.position_in_parent }}-{{ subchild.slug }}"
+                                {% else %}
+                                    href="{{ subchild.get_absolute_url }}{% if version %}?version={{ version }}{% endif %}"
+                                {% endif %}
                             {% endif %}
                             class="mobile-menu-link mobile-menu-sublink {% if current_container.long_slug == subchild.long_slug %}unread{% endif %}"
                         >

--- a/templates/tutorialv2/view/content.html
+++ b/templates/tutorialv2/view/content.html
@@ -153,7 +153,7 @@
              {%  endif %}
 
         {% else %}
-            <a href="{{ content.get_absolute_url }}" class="ico-after arrow-right blue new-btn">
+            <a href="{% url "content:view" content.pk content.slug_last_draft %}" class="ico-after arrow-right blue new-btn">
                 {% trans "Version brouillon" %}
             </a>
         {% endif %}

--- a/templates/tutorialv2/view/content.html
+++ b/templates/tutorialv2/view/content.html
@@ -153,7 +153,7 @@
              {%  endif %}
 
         {% else %}
-            <a href="{% url "content:view" content.pk content.slug_last_draft %}" class="ico-after arrow-right blue new-btn">
+            <a href="{% url "content:view" content.pk content.slug_repository %}" class="ico-after arrow-right blue new-btn">
                 {% trans "Version brouillon" %}
             </a>
         {% endif %}

--- a/zds/tutorialv2/mixins.py
+++ b/zds/tutorialv2/mixins.py
@@ -30,8 +30,6 @@ class SingleContentViewMixin(object):
             obj = queryset.first()
         else:
             obj = get_object_or_404(PublishableContent, pk=self.kwargs['pk'])
-        if 'slug' in self.kwargs and obj.slug != self.kwargs['slug']:
-            raise Http404
         if self.must_be_author and self.request.user not in obj.authors.all():
             if self.authorized_for_staff and self.request.user.has_perm('tutorial.change_tutorial'):
                 return obj
@@ -57,7 +55,13 @@ class SingleContentViewMixin(object):
                 raise PermissionDenied
 
         # load versioned file
-        return self.object.load_version_or_404(sha)
+        versioned = self.object.load_version_or_404(sha)
+
+        if 'slug' in self.kwargs \
+                and (versioned.slug != self.kwargs['slug'] and self.object.slug != self.kwargs['slug']):
+            raise Http404
+
+        return versioned
 
 
 class SingleContentPostMixin(SingleContentViewMixin):

--- a/zds/tutorialv2/tests/tests_views.py
+++ b/zds/tutorialv2/tests/tests_views.py
@@ -788,7 +788,7 @@ class ContentTests(TestCase):
                 'child_slug': self.extract1.slug,
                 'container_slug': self.chapter1.slug,
                 'first_level_slug': self.part1.slug,
-                'moving_method': 'before:'+self.extract3.get_path(True)[:-3],
+                'moving_method': 'before:' + self.extract3.get_path(True)[:-3],
                 'pk': tuto.pk
             },
             follow=True)
@@ -797,7 +797,7 @@ class ContentTests(TestCase):
         versioned = PublishableContent.objects.get(pk=tuto.pk).load_version()
         extract = versioned.children_dict[self.part1.slug].children_dict[self.chapter1.slug].children[0]
         self.assertEqual(self.extract2.slug, extract.slug)
-        
+
         tuto = PublishableContent.objects.get(pk=self.tuto.pk)
         old_sha = tuto.sha_draft
         # test changing parent for extract (smoothly)
@@ -809,11 +809,11 @@ class ContentTests(TestCase):
                 'child_slug': self.extract1.slug,
                 'container_slug': self.chapter1.slug,
                 'first_level_slug': self.part1.slug,
-                'moving_method': 'before:'+self.extract4.get_path(True)[:-3],
+                'moving_method': 'before:' + self.extract4.get_path(True)[:-3],
                 'pk': tuto.pk
             },
             follow=True)
-        
+
         self.assertEqual(200, result.status_code)
         self.assertNotEqual(old_sha, PublishableContent.objects.get(pk=tuto.pk).sha_draft)
         versioned = PublishableContent.objects.get(pk=tuto.pk).load_version()
@@ -831,7 +831,7 @@ class ContentTests(TestCase):
                 'child_slug': self.extract1.slug,
                 'container_slug': self.chapter2.slug,
                 'first_level_slug': self.part1.slug,
-                'moving_method': 'before:'+self.chapter1.get_path(True),
+                'moving_method': 'before:' + self.chapter1.get_path(True),
                 'pk': tuto.pk
             },
             follow=True)
@@ -852,7 +852,7 @@ class ContentTests(TestCase):
                 'child_slug': self.extract1.slug,
                 'container_slug': self.chapter2.slug,
                 'first_level_slug': self.part1.slug,
-                'moving_method': 'before:'+self.chapter1.get_path(True)+"/un-mauvais-extrait",
+                'moving_method': 'before:' + self.chapter1.get_path(True) + "/un-mauvais-extrait",
                 'pk': tuto.pk
             },
             follow=True)
@@ -864,7 +864,7 @@ class ContentTests(TestCase):
         extract = versioned.children_dict[self.part1.slug].children_dict[self.chapter2.slug].children[1]
         self.assertEqual(self.extract4.slug, extract.slug)
         self.assertEqual(2, len(versioned.children_dict[self.part1.slug].children_dict[self.chapter1.slug].children))
-    
+
     def test_move_container_before(self):
         # login with author
         self.assertEqual(
@@ -886,11 +886,11 @@ class ContentTests(TestCase):
                 'child_slug': self.chapter3.slug,
                 'container_slug': self.part1.slug,
                 'first_level_slug': '',
-                'moving_method': 'before:'+self.chapter4.get_path(True),
+                'moving_method': 'before:' + self.chapter4.get_path(True),
                 'pk': tuto.pk
             },
             follow=True)
-        
+
         self.assertEqual(200, result.status_code)
         self.assertNotEqual(old_sha, PublishableContent.objects.get(pk=tuto.pk).sha_draft)
         versioned = PublishableContent.objects.get(pk=tuto.pk).load_version()
@@ -908,11 +908,11 @@ class ContentTests(TestCase):
                 'child_slug': self.part1.slug,
                 'container_slug': self.tuto.slug,
                 'first_level_slug': '',
-                'moving_method': 'before:'+self.chapter4.get_path(True),
+                'moving_method': 'before:' + self.chapter4.get_path(True),
                 'pk': tuto.pk
             },
             follow=True)
-        
+
         self.assertEqual(200, result.status_code)
         self.assertEqual(old_sha, PublishableContent.objects.get(pk=tuto.pk).sha_draft)
         versioned = PublishableContent.objects.get(pk=tuto.pk).load_version()
@@ -921,7 +921,7 @@ class ContentTests(TestCase):
         self.assertEqual(self.chapter3.slug, chapter.slug)
         chapter = versioned.children_dict[self.part2.slug].children[1]
         self.assertEqual(self.chapter4.slug, chapter.slug)
-    
+
     def test_move_extract_after(self):
         # test 1 : move extract after a sibling
         # login with author
@@ -941,7 +941,7 @@ class ContentTests(TestCase):
                 'child_slug': self.extract1.slug,
                 'container_slug': self.chapter1.slug,
                 'first_level_slug': self.part1.slug,
-                'moving_method': 'after:'+self.extract3.get_path(True)[:-3],
+                'moving_method': 'after:' + self.extract3.get_path(True)[:-3],
                 'pk': tuto.pk
             },
             follow=True)
@@ -952,7 +952,7 @@ class ContentTests(TestCase):
         self.assertEqual(self.extract2.slug, extract.slug)
         extract = versioned.children_dict[self.part1.slug].children_dict[self.chapter1.slug].children[1]
         self.assertEqual(self.extract3.slug, extract.slug)
-        
+
         tuto = PublishableContent.objects.get(pk=self.tuto.pk)
         old_sha = tuto.sha_draft
         # test changing parent for extract (smoothly)
@@ -964,11 +964,11 @@ class ContentTests(TestCase):
                 'child_slug': self.extract1.slug,
                 'container_slug': self.chapter1.slug,
                 'first_level_slug': self.part1.slug,
-                'moving_method': 'after:'+self.extract4.get_path(True)[:-3],
+                'moving_method': 'after:' + self.extract4.get_path(True)[:-3],
                 'pk': tuto.pk
             },
             follow=True)
-        
+
         self.assertEqual(200, result.status_code)
         self.assertNotEqual(old_sha, PublishableContent.objects.get(pk=tuto.pk).sha_draft)
         versioned = PublishableContent.objects.get(pk=tuto.pk).load_version()
@@ -986,7 +986,7 @@ class ContentTests(TestCase):
                 'child_slug': self.extract1.slug,
                 'container_slug': self.chapter2.slug,
                 'first_level_slug': self.part1.slug,
-                'moving_method': 'after:'+self.chapter1.get_path(True),
+                'moving_method': 'after:' + self.chapter1.get_path(True),
                 'pk': tuto.pk
             },
             follow=True)
@@ -1007,7 +1007,7 @@ class ContentTests(TestCase):
                 'child_slug': self.extract1.slug,
                 'container_slug': self.chapter2.slug,
                 'first_level_slug': self.part1.slug,
-                'moving_method': 'after:'+self.chapter1.get_path(True)+"/un-mauvais-extrait",
+                'moving_method': 'after:' + self.chapter1.get_path(True) + "/un-mauvais-extrait",
                 'pk': tuto.pk
             },
             follow=True)
@@ -1019,7 +1019,7 @@ class ContentTests(TestCase):
         extract = versioned.children_dict[self.part1.slug].children_dict[self.chapter2.slug].children[0]
         self.assertEqual(self.extract4.slug, extract.slug)
         self.assertEqual(2, len(versioned.children_dict[self.part1.slug].children_dict[self.chapter1.slug].children))
-    
+
     def test_move_container_after(self):
         # login with author
         self.assertEqual(
@@ -1041,11 +1041,11 @@ class ContentTests(TestCase):
                 'child_slug': self.chapter3.slug,
                 'container_slug': self.part1.slug,
                 'first_level_slug': '',
-                'moving_method': 'after:'+self.chapter4.get_path(True),
+                'moving_method': 'after:' + self.chapter4.get_path(True),
                 'pk': tuto.pk
             },
             follow=True)
-        
+
         self.assertEqual(200, result.status_code)
         self.assertNotEqual(old_sha, PublishableContent.objects.get(pk=tuto.pk).sha_draft)
         versioned = PublishableContent.objects.get(pk=tuto.pk).load_version()
@@ -1063,11 +1063,11 @@ class ContentTests(TestCase):
                 'child_slug': self.part1.slug,
                 'container_slug': self.tuto.slug,
                 'first_level_slug': '',
-                'moving_method': 'after:'+self.chapter4.get_path(True),
+                'moving_method': 'after:' + self.chapter4.get_path(True),
                 'pk': tuto.pk
             },
             follow=True)
-        
+
         self.assertEqual(200, result.status_code)
         self.assertEqual(old_sha, PublishableContent.objects.get(pk=tuto.pk).sha_draft)
         versioned = PublishableContent.objects.get(pk=tuto.pk).load_version()
@@ -1076,7 +1076,7 @@ class ContentTests(TestCase):
         self.assertEqual(self.chapter3.slug, chapter.slug)
         chapter = versioned.children_dict[self.part2.slug].children[0]
         self.assertEqual(self.chapter4.slug, chapter.slug)
-        
+
     def tearDown(self):
         if os.path.isdir(settings.ZDS_APP['content']['repo_private_path']):
             shutil.rmtree(settings.ZDS_APP['content']['repo_private_path'])

--- a/zds/tutorialv2/utils.py
+++ b/zds/tutorialv2/utils.py
@@ -151,7 +151,6 @@ def try_adopt_new_child(adoptive_parent, child):
     :raise TooDeepContainerError: if the child is a container that is too deep to be adopted by the proposed parent
     :return:
     """
-    adoptive_parent
     if isinstance(child, Extract):
         if not adoptive_parent.can_add_extract():
             raise TypeError
@@ -165,49 +164,56 @@ def try_adopt_new_child(adoptive_parent, child):
         adoptive_parent.repo_delete('', False)
         adoptive_parent.add_container(child)
 
-def get_target_tagged_tree(moveable_child, root):
+
+def get_target_tagged_tree(movable_child, root):
     """
     Gets the tagged tree with deplacement availability
-    :param moveable_child: the extract we want to move
+    :param movable_child: the extract we want to move
     :param root: the VersionnedContent we use as root
-    :return: an array of tuples that represent the capacity of moveable_child to be moved near another child
+    :return: an array of tuples that represent the capacity of movable_child to be moved near another child
     check get_target_tagged_tree_for_extract and get_target_tagged_tree_for_container for format
     """
-    if isinstance(moveable_child, Extract):
-        return get_target_tagged_tree_for_extract(moveable_child, root)
+    if isinstance(movable_child, Extract):
+        return get_target_tagged_tree_for_extract(movable_child, root)
     else:
-        return get_target_tagged_tree_for_container(moveable_child, root)
-    
-def get_target_tagged_tree_for_extract(moveable_child, root):
+        return get_target_tagged_tree_for_container(movable_child, root)
+
+
+def get_target_tagged_tree_for_extract(movable_child, root):
     """
-    Gets the tagged tree with deplacement availability when moveable_child is an extract
-    :param moveable_child: the extract we want to move
+    Gets the tagged tree with displacement availability when movable_child is an extract
+    :param movable_child: the extract we want to move
     :param root: the VersionnedContent we use as root
-    :return: an array of tuples that represent the capacity of moveable_child to be moved near another child
-    tuples are (relative_path, title, level, can_be_a_target) 
+    :return: an array of tuples that represent the capacity of movable_child to be moved near another child
+    tuples are (relative_path, title, level, can_be_a_target)
     """
     target_tagged_tree = []
     for child in root.traverse(False):
-        if is_instance(child, Extract):
-            target_tagged_tree.append((child.get_full_slug(), child.title, child.get_tree_level(), child != moveable_child))
+        if isinstance(child, Extract):
+            target_tagged_tree.append((child.get_full_slug(),
+                                       child.title,
+                                       child.container.get_tree_level() + 1,
+                                       child != movable_child))
         else:
             target_tagged_tree.append((child.get_path(True), child.title, child.get_tree_level(), False))
-    
+
     return target_tagged_tree
-    
-def get_target_tagged_tree_for_container(moveable_child, root):
+
+
+def get_target_tagged_tree_for_container(movable_child, root):
     """
-    Gets the tagged tree with deplacement availability when moveable_child is an extract
-    :param moveable_child: the container we want to move
+    Gets the tagged tree with displacement availability when movable_child is an extract
+    :param movable_child: the container we want to move
     :param root: the VersionnedContent we use as root
-    :return: an array of tuples that represent the capacity of moveable_child to be moved near another child
+    :return: an array of tuples that represent the capacity of movable_child to be moved near another child
     extracts are not included
     """
     target_tagged_tree = []
     for child in root.traverse(True):
-        composed_depth = child.get_tree_depth() + moveable_child.get_tree_level()
+        composed_depth = child.get_tree_depth() + movable_child.get_tree_level()
         enabled = composed_depth <= settings.ZDS_APP['content']['max_tree_depth']
-        target_tagged_tree.append((child.get_path(True), child.title, child.get_tree_level(),
-            enabled and child != moveable_child and child != root))
-    
+        target_tagged_tree.append((child.get_path(True),
+                                   child.title, child.get_tree_level(),
+                                   enabled and child != movable_child and child != root))
+
     return target_tagged_tree

--- a/zds/tutorialv2/views.py
+++ b/zds/tutorialv2/views.py
@@ -374,7 +374,7 @@ class EditContainer(LoggedWithReadWriteHability, SingleContentFormViewMixin):
     content = None
 
     def get_context_data(self, **kwargs):
-        context = super(EditContainer, self).get_context_data(**kwargs) 
+        context = super(EditContainer, self).get_context_data(**kwargs)
 
         return context
 
@@ -1001,7 +1001,7 @@ class MoveChild(LoginRequiredMixin, SingleContentPostMixin, FormView):
         versioned = content.load_version()
         base_container_slug = form.data["container_slug"]
         child_slug = form.data['child_slug']
-        
+
         if base_container_slug == '':
             raise Http404
 
@@ -1014,13 +1014,12 @@ class MoveChild(LoginRequiredMixin, SingleContentPostMixin, FormView):
             search_params = {}
 
             if form.data['first_level_slug'] != '':
-                
                 search_params['parent_container_slug'] = form.data['first_level_slug']
                 search_params['container_slug'] = base_container_slug
             else:
                 search_params['container_slug'] = base_container_slug
             parent = search_container_or_404(versioned, search_params)
-        
+
         try:
             child = parent.children_dict[child_slug]
             if form.data['moving_method'] == MoveElementForm.MOVE_UP:
@@ -1034,7 +1033,7 @@ class MoveChild(LoginRequiredMixin, SingleContentPostMixin, FormView):
                         target_parent = versioned
                     else:
                         target_parent = search_container_or_404(versioned, "/".join(target.split("/")[:-1]))
-                        
+
                         if target.split("/")[-1] not in target_parent.children_dict:
                             raise Http404
                     child = target_parent.children_dict[target.split("/")[-1]]
@@ -1053,7 +1052,7 @@ class MoveChild(LoginRequiredMixin, SingleContentPostMixin, FormView):
                             raise Http404
                     child = target_parent.children_dict[target.split("/")[-1]]
                     try_adopt_new_child(target_parent, parent.children_dict[child_slug])
-                    
+
                     parent = target_parent
                 parent.move_child_before(child_slug, target.split("/")[-1])
 
@@ -1066,8 +1065,8 @@ class MoveChild(LoginRequiredMixin, SingleContentPostMixin, FormView):
             content.save()
             messages.info(self.request, _(u"L'élément a bien été déplacé."))
         except TooDeepContainerError:
-            messages.error(self.request, _(u'Cette section contient déjà trop de sous-section pour devenir'\
-                ' la sous-section d\'une autre section.'))
+            messages.error(self.request, _(u'Cette section contient déjà trop de sous-section pour devenir'
+                                           u' la sous-section d\'une autre section.'))
         except ValueError:
             raise Http404
         except IndexError:
@@ -1077,7 +1076,7 @@ class MoveChild(LoginRequiredMixin, SingleContentPostMixin, FormView):
 
         if base_container_slug == versioned.slug:
             return redirect(reverse("content:view", args=[content.pk, content.slug]))
-        else:                
+        else:
             return redirect(child.get_absolute_url())
 
 


### PR DESCRIPTION
Cette PR s'intéresse au fait qu'avant, on ne pouvait plus accéder aux anciennes version d'un contenu si son titre (et donc son slug) changeait. À priori, maintenant on peut. J'en ai profité pour faire deux T.U. qui, je l'espère couvrent ça. 

Les T.U. en questions m'ont permis de constater qu'il y avait des choses qui ne fonctionnaient pas, et donc je les ais fixées au passages (en gros, les fonctions `repo_*()`). Voilà :)
