### PR TITLE
Zep 12 validation and publication

### DIFF
--- a/templates/tutorialv2/base_online.html
+++ b/templates/tutorialv2/base_online.html
@@ -4,7 +4,7 @@
 
 
 {% block title_base %}
-    &bull; {{ verbose_type_name_plural }}
+    &bull; {{ verbose_type_name_plural|title }}
 {% endblock %}
 
 

--- a/templates/tutorialv2/base_online.html
+++ b/templates/tutorialv2/base_online.html
@@ -1,0 +1,38 @@
+{% extends "tutorialv2/base.html" %}
+{% load captureas %}
+{% load i18n %}
+
+
+{% block title_base %}
+    &bull; {{ verbose_type_name_plural }}
+{% endblock %}
+
+
+
+{% block canonical %}
+    {% if content.source and content.source != "" %}
+    	<link rel="canonical" href="{{ content.source }}">
+    {% endif %}
+{% endblock %}
+
+
+
+{% block breadcrumb_base %}
+    <li itemscope itemtype="http://data-vocabulary.org/Breadcrumb">
+        <a
+            {% if content_type == "ARTICLE" %}
+                href="{% url "article:list" %}"
+            {% elif content_type == "TUTORIAL" %}
+                href="{% url "tutorial:list" %}"
+            {% endif %}
+            itemprop="url">
+            <span itemprop="title">{{ verbose_type_name_plural|title }}</span>
+        </a>
+    </li>
+{% endblock %}
+
+
+
+{% block article_schema %}
+    itemscope itemtype="http://schema.org/Article"
+{% endblock %}

--- a/templates/tutorialv2/includes/child_online.part.html
+++ b/templates/tutorialv2/includes/child_online.part.html
@@ -1,0 +1,40 @@
+{% load emarkdown %}
+{% load i18n %}
+{% load times %}
+{% load target_tree %}
+
+<h2 id="{{ child.position_in_parent }}-{{ child.slug }}">
+    <a href="{{ child.get_absolute_url_online }}">
+        {{ child.title }}
+    </a>
+</h2>
+
+
+{% if child.has_extracts %}
+    <ol>
+        {% for extract in child.children %}
+        <li>
+            <a href="{{ extract.container.get_absolute_url_online }}#{{ extract.position_in_parent }}-{{ extract.slug }}">{{ extract.title }}</a>
+        </li>
+        {% endfor %}
+    </ol>
+{%  elif child.has_sub_containers %}
+    <ol class="summary-part">
+        {% for subchild in child.children %}
+        <li>
+            <h3>
+                <a href="{{ subchild.get_absolute_url_online }}">{{ subchild.title }}</a>
+            </h3>
+            <ol class="summary-part">
+                {% for extract in subchild.children %}
+                    <li>
+                        <h4>
+                            <a href="{{ extract.container.get_absolute_url_online }}#{{ extract.position_in_parent }}-{{ extract.slug }}">{{ extract.title }}</a>
+                        </h4>
+                    </li>
+                {% endfor %}
+            </ol>
+        </li>
+        {% endfor %}
+    </ol>
+{% endif %}

--- a/templates/tutorialv2/includes/container_online_template.part.html
+++ b/templates/tutorialv2/includes/container_online_template.part.html
@@ -1,0 +1,37 @@
+{% load emarkdown %}
+
+{# this template will be used to generate the HTML file for each container ! #}
+
+
+{% if container.introduction %}
+    {{ container.get_introduction|emarkdown }}
+{% endif %}
+
+{% if container.children|length != 0 %}
+    <ul>
+        {% for extract in container.children %}
+            <li>
+                <a href="#{{ extract.position_in_parent }}-{{ extract.slug }}">
+                    {{ extract.title }}
+                </a>
+            </li>
+        {% endfor %}
+    </ul>
+{% endif %}
+
+{% for extract in container.children %}
+    <h2 id="{{ extract.position_in_parent }}-{{ extract.slug }}">
+        <a href="#{{ extract.position_in_parent }}-{{ extract.slug }}">
+            {{ extract.title }}
+        </a>
+    </h2>
+    {% if extract.text %}
+        {{ extract.get_text|emarkdown }}
+    {% endif %}
+{% endfor %}
+
+<hr />
+
+{% if container.conclusion %}
+    {{ container.get_conclusion|emarkdown }}
+{% endif %}

--- a/templates/tutorialv2/includes/content_item.part.html
+++ b/templates/tutorialv2/includes/content_item.part.html
@@ -4,9 +4,7 @@
 
 <article>
     <a href="
-        {% if type == 'public' and content.in_public %}
-            {{ content.get_absolute_url_online }}
-        {% elif type == 'beta' and content.in_beta %}
+        {% if type == 'beta' and content.in_beta %}
             {{ content.get_absolute_url_beta }}
         {% else %}
             {{ content.get_absolute_url }}
@@ -19,6 +17,9 @@
             <span class="article-metadata">
                 {% if content.subcategory.all %}
                     {% for category in content.subcategory.all %}
+                        {% if not forloop.first %}
+                            -
+                        {% endif %}
                         {{ category.title }}
                     {% endfor %}
                 {% else %}

--- a/templates/tutorialv2/includes/content_online_item.part.html
+++ b/templates/tutorialv2/includes/content_online_item.part.html
@@ -1,0 +1,35 @@
+{% load thumbnail %}
+{% load date %}
+{% load i18n %}
+{% load captureas %}
+
+<article>
+    <img src="{{ public_content.content.image.physical.tutorial_illu.url }}" alt="" class="tutorial-img avatar">
+    <div class="tutorial-infos">
+        <a href="{{ public_content.get_absolute_url_online }}">
+            <h3>{{ public_content.content.title }}</h3>
+        </a>
+        <span class="article-metadata">
+            {% if public_content.content.subcategory.all %}
+                {% for category in public_content.content.subcategory.all %}
+                    {% if not forloop.first %}
+                        -
+                    {% endif %}
+
+                    {% captureas list_content_url %}
+                        {% if public_content.is_article %}
+                            {% url "article:list" %}
+                        {% elif public_content.is_tutorial %}
+                            {% url "tutorial:list" %}
+                        {% endif %}
+                    {% endcaptureas %}
+
+                    <a href="{{ list_content_url }}?tag={{ category.slug }}">{{ category.title }}</a>
+                {% endfor %}
+            {% else %}
+                {% trans "Aucune catégorie" %}
+            {% endif %}
+            - {{ public_content.publication_date|format_date }}
+        </span>
+    </div>
+</article>

--- a/templates/tutorialv2/includes/opengraph.part.html
+++ b/templates/tutorialv2/includes/opengraph.part.html
@@ -1,0 +1,13 @@
+<meta property="og:type" content="article">
+
+{% if tutorial.create_at %}
+    <meta property="og:article:published_time" content="{{ content.creation_date|date:"c" }}">
+{% endif %}
+{% if tutorial.pubdate %}
+    <meta property="og:article:modified_time" content="{{ content.pubdate|date:"c" }}">
+{% endif %}
+
+<meta property="og:article:section" content="Tutoriels">
+{% for catofsubcat in content.subcategory.all %}
+    <meta property="og:article:tag" content="{{ catofsubcat.title }}">
+{% endfor %}

--- a/templates/tutorialv2/includes/tags_authors.part.html
+++ b/templates/tutorialv2/includes/tags_authors.part.html
@@ -15,10 +15,17 @@
 
 {% if content.update_date %}
     <span class="pubdate">
+    {% if online %}
+        {% trans "Publié" %} :
+        <time datetime="{{ content.update_date|date:"c" }}" pubdate="pubdate" itemprop="dateModified">
+            {{ public_object.publication_date|format_date }}
+        </time>
+    {% else %}
         {% trans "Dernière mise à jour" %} :
         <time datetime="{{ content.update_date|date:"c" }}" pubdate="pubdate" itemprop="dateModified">
             {{ content.update_date|format_date }}
         </time>
+    {% endif %}
     </span>
 {% endif %}
 

--- a/templates/tutorialv2/index_online.html
+++ b/templates/tutorialv2/index_online.html
@@ -1,0 +1,138 @@
+{% extends "tutorialv2/base_online.html" %}
+{% load date %}
+{% load i18n %}
+{% load captureas %}
+
+
+{% block title %}
+    {% if tag %}
+        {{ tag }}
+    {% else %}
+        {% trans "Tous les" %} {{ verbose_type_name_plural }}
+    {% endif %}
+{% endblock %}
+
+
+
+{% block description %}
+    {% if tag %}
+        {% blocktrans %}
+            Découvrez tous nos {{ verbose_type_name_plural }} sur {{ tag }}. Vous pourrez également découvrir divers sujets tous plus intéressants les uns que les autres !
+        {% endblocktrans %}
+    {% else %}
+        {% blocktrans %}
+            Les {{ verbose_type_name_plural }} vous permettent d'apprendre divers sujets tous plus intéressants les uns que les autres.
+        {% endblocktrans %}
+    {% endif %}
+{% endblock %}
+
+
+
+{% block breadcrumb %}
+    {% if tag %}
+        <li>{{ tag }}</li>
+    {% else %}
+        <li>{% trans "Tous les" %} {{ verbose_type_name_plural }}</li>
+    {% endif %}
+{% endblock %}
+
+
+
+{% block content_out %}
+    <section class="full-content-wrapper" itemscope itemtype="http://schema.org/ItemList">
+        <h1 class="ico-after ico-{% if content_type == "TUTORIAL" %}tutorials{% else %}articles{% endif %}" itemprop="name">
+            {% block headline %}
+                {% if tag %}
+                    {{ verbose_type_name_plural|title }} : {{ tag }}
+                {% else %}
+                    {% trans "Tous les" %} {{ verbose_type_name_plural }}
+                {% endif %}
+            {% endblock %}
+        </h1>
+
+        <meta itemprop="itemListOrder" content="Unordered">
+
+        {% if public_contents %}
+            <div class="tutorial-list">
+                {% for public_content in public_contents %}
+                    {% include "tutorialv2/includes/content_online_item.part.html" %}
+                {% endfor %}
+            </div>
+        {% else %}
+            <p>
+                {% trans "Aucun tutoriel disponible" %}.
+            </p>
+        {% endif %}
+    </section>
+{% endblock %}
+
+
+
+{% block sidebar %}
+    <aside class="sidebar accordeon mobile-menu-bloc" data-title="{% trans "Catégories des" %} {{ verbose_type_name_plural }}">
+        <a href="{% url "content:create" %}" class="new-btn ico-after more blue">
+            {% trans "Nouveau contenu" %}
+        </a>
+
+        <a href="{% url "zds.tutorial.views.help_tutorial" %}" class="new-btn ico-after help blue">
+            {% trans "Aider les auteurs" %}
+        </a>
+
+        <h3>{% blocktrans %} Catégories <span class="wide">des {{ verbose_type_name_plural }}</span> {% endblocktrans %}</h3>
+
+        {% captureas content_list_url %}
+            {% if content_type == "ARTICLE" %}
+                {% url "article:list" %}
+            {% elif content_type == "TUTORIAL" %}
+                {% url "tutorial:list" %}
+            {% endif %}
+        {% endcaptureas %}
+
+        {% for title, subcats in top_categories.items %}
+            <h4 class="mobile-menu-link">{{ title }}</h4>
+            <ul>
+                {% for subcat,slug in subcats %}
+                    <li>
+                        <a href="{{ content_list_url }}?tag={{ slug }}" class="mobile-menu-link mobile-menu-sublink">
+                            {{  subcat }}
+                        </a>
+                    </li>
+                {% endfor %}
+            </ul>
+        {% empty %}
+            <ul>
+                <li>
+                    {% trans "Aucune catégorie disponible." %}
+                </li>
+            </ul>
+        {% endfor %}
+
+        <div class="mobile-menu-bloc mobile-all-links" data-title="Flux">
+            <h3>{% trans "Flux" %}</h3>
+            <ul>
+                <li>
+                    <a
+                        {% if content_type == "ARTICLE" %}
+                            href="{% url "article:feed-rss" %}"
+                        {% elif content_type == "TUTORIAL" %}
+                            href="{% url "tutorial:feed-rss" %}"
+                        {% endif %}
+                    class="ico-after rss blue">
+                        {% blocktrans %} Nouveaux {{ verbose_type_name_plural }} (RSS) {% endblocktrans %}
+                    </a>
+                </li>
+                <li>
+                    <a
+                        {% if content_type == "ARTICLE" %}
+                            href="{% url "article:feed-atom" %}"
+                        {% elif content_type == "TUTORIAL" %}
+                            href="{% url "tutorial:feed-atom" %}"
+                        {% endif %}
+                    class="ico-after rss blue">
+                        {% blocktrans %} Nouveaux {{ verbose_type_name_plural }} (ATOM) {% endblocktrans %}
+                    </a>
+                </li>
+            </ul>
+        </div>
+    </aside>
+{% endblock %}

--- a/templates/tutorialv2/messages/validation_accept_content.msg.html
+++ b/templates/tutorialv2/messages/validation_accept_content.msg.html
@@ -1,0 +1,11 @@
+{% load i18n %}
+
+{% blocktrans with title=content.title validator_name=validator.username validator_url=validator.get_absolute_url %}
+
+Félicitations !
+
+Le zeste « [{{ title }}]({{ url }}) » a été publié par [{{ validator_name }}]({{ validator_url }}) ! Les lecteurs du monde entier peuvent désormais venir le consulter, l'éplucher et réagir à son sujet.
+Je conseille de rester à leur écoute afin d'apporter des corrections et/ou compléments: un contenu vivant et à jour est bien plus lu qu'un sujet abandonné !
+
+{%  endblocktrans %}
+

--- a/templates/tutorialv2/messages/validation_accept_update.html
+++ b/templates/tutorialv2/messages/validation_accept_update.html
@@ -1,0 +1,10 @@
+{% load i18n %}
+
+{% blocktrans with title=content.title validator_name=validator.username validator_url=validator.get_absolute_url %}
+
+Salut !
+
+La mise à jour sur « [{{ title }}]({{ url }}) » a été publié par [{{ validator_name }}]({{ validator_url }}), et tout le monde peut désormais la découvrir.
+
+{%  endblocktrans %}
+

--- a/templates/tutorialv2/messages/validation_change.msg.html
+++ b/templates/tutorialv2/messages/validation_change.msg.html
@@ -1,0 +1,18 @@
+{% load i18n %}
+{% load captureas %}
+
+{% captureas url_list %}
+    {% url "content:list-validation" %}
+{% endcaptureas %}
+
+{% blocktrans with title=content.title %}
+
+Bonjour {{ validator }},
+
+Le contenu de « [{{ title }}]({{ url }}) », que tu avait réservé, a été mis à jour en zone de validation.
+Pour voir les modifications qui ont été faites, je t'invite à consulter [l'historique]({{ url_history }}).
+
+Si tu comptes le valider, il te faudra le réserver à nouveau en te rendant sur [la page des validations]({{ url_list }}).
+
+{%  endblocktrans %}
+

--- a/templates/tutorialv2/messages/validation_reject.msg.html
+++ b/templates/tutorialv2/messages/validation_reject.msg.html
@@ -1,0 +1,14 @@
+{% load i18n %}
+
+{% blocktrans with title=content.title validator_name=validator.username validator_url=validator.get_absolute_url message=message_reject|safe %}
+
+Désolé, « [{{ title }}]({{ url }}) » n'a malheureusement pas passé l’étape de validation.
+
+Mais pas de panique, certaines corrections peuvent surement être faite pour l'améliorer et repasser la validation plus tard.
+Voici le message que [{{ validator_name }}]({{ validator_url }}), le validateur, a laissé:
+
+{{ message }}
+
+N'hésite pas a lui envoyer un petit message pour discuter de la décision ou demander plus de détail si tout cela te semble injuste ou manque de clarté !
+
+{% endblocktrans %}

--- a/templates/tutorialv2/messages/validation_revoke.msg.html
+++ b/templates/tutorialv2/messages/validation_revoke.msg.html
@@ -1,0 +1,11 @@
+{% load i18n %}
+
+{% blocktrans with title=content.title admin_name=admin.username admin_url=admin.get_absolute_url message=message_reject|safe %}
+
+Désolé, « [{{ title }}]({{ url }}) » a malheureusement été dépublié par [{{ admin_name }}]({{ admin_url }}). Voici le message qu'il a laissé :
+
+{{ message }}
+
+N'hésite pas a lui envoyer un petit message pour discuter de la décision ou demander plus de détail si tout cela te semble injuste ou manque de clarté !
+
+{% endblocktrans %}

--- a/templates/tutorialv2/validation/history.html
+++ b/templates/tutorialv2/validation/history.html
@@ -1,4 +1,4 @@
-{% extends "tutorialv2/validation/index.html" %}
+{% extends "tutorialv2/base.html" %}
 {% load date %}
 {% load captureas %}
 {% load emarkdown %}
@@ -20,19 +20,27 @@
 
 
 {% block headline %}
-    {{ content.title }}
-{% endblock %}
+    <h1 {% if content.image %}class="illu"{% endif %}>
+        {% if content.image %}
+            <img src="{{ content.image.physical.tutorial_illu.url }}" alt="">
+        {% endif %}
+        {{ content.title }}
+    </h1>
 
+    <h2 class="subtitle">
+        {% trans "Historique de validation" %}
+    </h2>
 
-{% block headline_sub %}
-    {% trans "Historique de validation" %}
+    {% if user.user in content.authors.all %}
+        {% include 'tutorialv2/includes/tags_authors.part.html' with content=content add_author=True %}
+    {% else %}
+        {% include 'tutorialv2/includes/tags_authors.part.html' with content=content %}
+    {% endif %}
 {% endblock %}
 
 
 
 {% block content %}
-    {% include "tutorial/includes/tags_authors.part.html" %}
-
     {% if validations %}
         <table class="fullwidth">
             <thead>
@@ -60,7 +68,7 @@
                         </td>
                         <td>
                             {% captureas reservation_url %}
-                                {% url "content:reserve_validation" validation.pk %}
+                                {% url "content:reserve-validation" validation.pk %}
                             {% endcaptureas %}
                             {% include "misc/validation.part.html" %}
                         </td>

--- a/templates/tutorialv2/validation/history.html
+++ b/templates/tutorialv2/validation/history.html
@@ -11,8 +11,8 @@
 
 
 
-{% block breadcrumb %}
-    <li><a href="{% url "content:list_validation" %}">{% trans "Validation" %}</a></li>
+{% block breadcrumb_base %}
+    <li><a href="{% url "content:list-validation" %}">{% trans "Validation" %}</a></li>
     <li><a href="{{ content.get_absolute_url }}">{{ content.title }}</a></li>
     <li>{% trans "Historique" %}</li>
 {% endblock %}

--- a/templates/tutorialv2/validation/index.html
+++ b/templates/tutorialv2/validation/index.html
@@ -1,4 +1,4 @@
-{% extends "tutorial/base_online.html" %}
+{% extends "tutorialv2/base.html" %}
 {% load date %}
 {% load captureas %}
 {% load i18n %}
@@ -30,6 +30,13 @@
                     / {% trans "Reservés" %}
                 {% elif request.GET.type == "orphan" %}
                     / {% trans "Non-reservés" %}
+                {% elif request.GET.type == "article" %}
+                    / {% trans "Articles" %}
+                {% elif request.GET.type == "tuto" %}
+                    / {% trans "Tutoriels" %}
+                {% endif %}
+                {%  if category %}
+                    / {{ category.title }}
                 {% endif %}
                 ({{ validations|length }})
             {% endblock %}
@@ -48,6 +55,7 @@
                     <thead>
                         <tr>
                             <th>{% trans "Titre" %}</th>
+                            <th width="5%">{% trans "Type" %}</th>
                             <th width="15%">{% trans "Auteur(s)" %}</th>
                             <th width="10%">{% trans "Propos" %}é</th>
                             <th width="24%">{% trans "Statut" %}</th>
@@ -68,10 +76,18 @@
                                                 -
                                             {% endif %}
                                             <a href="{% url "content:list_validation" %}?subcategory={{ subcategory.pk }}">
-                                                {{ subcategory.title }}</a>
+                                                {{ subcategory.title }}
+                                            </a>
                                         {% endfor %}
                                     {% else %}
                                         <em>{% trans "Aucune catégorie" %}</em>
+                                    {% endif %}
+                                </td>
+                                <td>
+                                    {% if validation.content.type == "ARTICLE" %}
+                                        <a href="{% url "content:list_validation" %}?type=article">Article</a>
+                                    {% else %}
+                                        <a href="{% url "content:list_validation" %}?type=tuto">Tutoriel</a>
                                     {% endif %}
                                 </td>
                                 <td>
@@ -84,7 +100,7 @@
                                 </td>
                                 <td>
                                     {% captureas reservation_url %}
-                                        {% url "content:reserve_validation" validation.pk %}
+                                        {% url "content:reserve-validation" validation.pk %}
                                     {% endcaptureas %}
                                     {% include "misc/validation.part.html" %}
                                 </td>
@@ -94,7 +110,10 @@
                 </table>
             {% else %}
                 <p>
-                    {% trans "Aucun tutoriel soumis en validation" %}.
+                    {% trans "Aucun contenu en validation" %}
+                    {% if request.GET.type %}
+                        {% trans " ne répond à ce critère" %}
+                    {% endif %}
                 </p>
             {% endif %}
         {% endblock %}
@@ -118,9 +137,19 @@
                     {% trans "En attente de validateur" %}
                 </a>
             </li>
-            {% if request.GET.type %}
+            <li>
+                <a href="{% url "content:list_validation" %}?type=article" class="ico-after view {% if request.GET.type == "article" %}unread{% endif %}">
+                    {% trans "Articles" %}
+                </a>
+            </li>
+            <li>
+                <a href="{% url "content:list_validation" %}?type=tuto" class="ico-after view {% if request.GET.type == "tuto" %}unread{% endif %}">
+                    {% trans "Tutoriels" %}
+                </a>
+            </li>
+            {% if request.GET.type or request.GET.subcategory %}
                 <li>
-                    <a href="{% url "content:list_validation" %}" class="ico-after cross blue">
+                    <a href="{% url "content:list_validation" %}" class="ico-after cross red">
                         {% trans "Annuler le filtre" %}
                     </a>
                 </li>

--- a/templates/tutorialv2/validation/index.html
+++ b/templates/tutorialv2/validation/index.html
@@ -1,21 +1,24 @@
-{% extends "tutorialv2/base.html" %}
+{% extends "tutorialv2/base_online.html" %}
 {% load date %}
 {% load captureas %}
 {% load i18n %}
 
+{% block title_base %}
+    &bull; {% trans "Validation" %}
+{% endblock %}
 
 {% block title %}
     {% trans "Validation" %}
     {% if request.GET.type == "reserved" %}
-        / {% trans "Reservés" %}
+        / {% trans "Réservés" %}
     {% elif request.GET.type == "orphan" %}
-        / {% trans "Non-reservés" %}
+        / {% trans "Non-réservés" %}
     {% endif %}
 {% endblock %}
 
 
 
-{% block breadcrumb %}
+{% block breadcrumb_base %}
     <li>{% trans "Validation" %}</li>
 {% endblock %}
 
@@ -75,7 +78,7 @@
                                             {% if not forloop.first %}
                                                 -
                                             {% endif %}
-                                            <a href="{% url "content:list_validation" %}?subcategory={{ subcategory.pk }}">
+                                            <a href="{% url "content:list-validation" %}?subcategory={{ subcategory.pk }}">
                                                 {{ subcategory.title }}
                                             </a>
                                         {% endfor %}
@@ -85,9 +88,9 @@
                                 </td>
                                 <td>
                                     {% if validation.content.type == "ARTICLE" %}
-                                        <a href="{% url "content:list_validation" %}?type=article">Article</a>
+                                        <a href="{% url "content:list-validation" %}?type=article">Article</a>
                                     {% else %}
-                                        <a href="{% url "content:list_validation" %}?type=tuto">Tutoriel</a>
+                                        <a href="{% url "content:list-validation" %}?type=tuto">Tutoriel</a>
                                     {% endif %}
                                 </td>
                                 <td>
@@ -128,28 +131,28 @@
         <h3>{% trans "Filtres" %}</h3>
         <ul>
             <li>
-                <a href="{% url "content:list_validation" %}?type=reserved" class="ico-after tick green {% if request.GET.type == "reserved" %}unread{% endif %}">
+                <a href="{% url "content:list-validation" %}?type=reserved" class="ico-after tick green {% if request.GET.type == "reserved" %}unread{% endif %}">
                     {% trans "En cours de validation" %}
                 </a>
             </li>
             <li>
-                <a href="{% url "content:list_validation" %}?type=orphan" class="ico-after tick {% if request.GET.type == "orphan" %}unread{% endif %}">
+                <a href="{% url "content:list-validation" %}?type=orphan" class="ico-after tick {% if request.GET.type == "orphan" %}unread{% endif %}">
                     {% trans "En attente de validateur" %}
                 </a>
             </li>
             <li>
-                <a href="{% url "content:list_validation" %}?type=article" class="ico-after view {% if request.GET.type == "article" %}unread{% endif %}">
+                <a href="{% url "content:list-validation" %}?type=article" class="ico-after view {% if request.GET.type == "article" %}unread{% endif %}">
                     {% trans "Articles" %}
                 </a>
             </li>
             <li>
-                <a href="{% url "content:list_validation" %}?type=tuto" class="ico-after view {% if request.GET.type == "tuto" %}unread{% endif %}">
+                <a href="{% url "content:list-validation" %}?type=tuto" class="ico-after view {% if request.GET.type == "tuto" %}unread{% endif %}">
                     {% trans "Tutoriels" %}
                 </a>
             </li>
             {% if request.GET.type or request.GET.subcategory %}
                 <li>
-                    <a href="{% url "content:list_validation" %}" class="ico-after cross red">
+                    <a href="{% url "content:list-validation" %}" class="ico-after cross red">
                         {% trans "Annuler le filtre" %}
                     </a>
                 </li>

--- a/templates/tutorialv2/view/container.html
+++ b/templates/tutorialv2/view/container.html
@@ -73,10 +73,6 @@
         </ul>
     {% endif %}
 
-
-
-    <hr />
-
     {% for child in container.children %}
         {%  include "tutorialv2/includes/child.part.html" with child=child %}
     {% empty %}

--- a/templates/tutorialv2/view/container_online.html
+++ b/templates/tutorialv2/view/container_online.html
@@ -1,0 +1,97 @@
+{% extends "tutorialv2/base_online.html" %}
+{% load set %}
+{% load thumbnail %}
+{%  load emarkdown %}
+{% load i18n %}
+{% load times %}
+
+
+{% block title %}
+    {{ container.title }} - {{ content.title }}
+{% endblock %}
+
+
+
+{% block opengraph %}
+    {% include "tutorialv2/includes/opengraph.part.html" %}
+{% endblock %}
+
+
+
+{% block breadcrumb %}
+    {%  if container.parent.parent %}
+        <li itemscope itemtype="http://data-vocabulary.org/Breadcrumb">
+            <span itemprop="title"><a href="{{ container.parent.parent.get_absolute_url_online }}">{{ container.parent.parent.title }}</a></span>
+        </li>
+    {% endif %}
+
+    {%  if container.parent %}
+        <li itemscope itemtype="http://data-vocabulary.org/Breadcrumb">
+            <span itemprop="title"><a href="{{ container.parent.get_absolute_url_online }}">{{ container.parent.title }}</a></span>
+        </li>
+    {% endif %}
+
+    <li>{{ container.title }}</li>
+{% endblock %}
+
+
+
+{% block headline %}
+    {% if content.licence %}
+        <p class="license">
+            {{ content.licence }}
+        </p>
+    {% endif %}
+
+    <h1>
+        {{ container.title }}
+    </h1>
+
+    {% include 'tutorialv2/includes/tags_authors.part.html' %}
+{% endblock %}
+
+
+
+{% block content %}
+    {% include "tutorialv2/includes/chapter_pager.part.html" with position="top" online=True %}
+
+    {% if container.has_extracts %}
+        {{ container.get_content_online|safe }}
+    {% else %}
+
+        {% if container.introduction %}
+            {{ container.get_introduction_online|safe }}
+        {% endif %}
+
+        {% for child in container.children %}
+            {%  include "tutorialv2/includes/child_online.part.html" with child=child %}
+        {% endfor %}
+
+        <hr class="clearfix" />
+        <hr />
+
+        {% if container.conclusion %}
+            {{ container.get_conclusion_online|safe }}
+        {% endif %}
+
+    {% endif %}
+
+    {% include "tutorialv2/includes/chapter_pager.part.html" with position="bottom" online=True %}
+{% endblock %}
+
+
+
+{% block sidebar_blocks %}
+    {% if perms.tutorial.change_tutorial %}
+        <div class="mobile-menu-bloc mobile-all-links mobile-show-ico" data-title="Administration">
+            <h3>{% blocktrans %}Admin<span class="wide">istration</span>{% endblocktrans %}</h3>
+            <ul>
+                <li><a href="{{ container.get_absolute_url }}" class="ico-after offline blue">{% trans "Version hors-ligne" %}</a></li>
+            </ul>
+        </div>
+    {% endif %}
+
+    {% include "tutorialv2/includes/summary.part.html" with current_container=container online=True %}
+
+    {% include "misc/social_buttons.part.html" with link=container.get_absolute_url_online text=container.title %}
+{% endblock %}

--- a/templates/tutorialv2/view/container_online.html
+++ b/templates/tutorialv2/view/container_online.html
@@ -47,7 +47,7 @@
         {{ container.title }}
     </h1>
 
-    {% include 'tutorialv2/includes/tags_authors.part.html' %}
+    {% include 'tutorialv2/includes/tags_authors.part.html' with content=content online=True %}
 {% endblock %}
 
 

--- a/templates/tutorialv2/view/content.html
+++ b/templates/tutorialv2/view/content.html
@@ -108,9 +108,17 @@
         </p>
     {% endif %}
 
-
-
-    <hr />
+    {% if content.has_extracts %}
+        <ul>
+            {% for extract in content.children %}
+                <li>
+                    <a href="#{{ extract.position_in_parent }}-{{ extract.slug }}">
+                        {{ extract.title }}
+                    </a>
+                </li>
+            {% endfor %}
+        </ul>
+    {% endif %}
 
     {% for child in content.children %}
         {%  include "tutorialv2/includes/child.part.html" with child=child %}
@@ -247,11 +255,13 @@
             </a>
         </li>
         {% if not content.in_validation %}
-            <li>
-                <a href="#ask-validation" class="open-modal ico-after tick green">
-                    {% trans "Demander la validation" %}
-                </a>
-            </li>
+            {% if content.current_version != content.sha_public %}
+                <li>
+                    <a href="#ask-validation" class="open-modal ico-after tick green">
+                        {% trans "Demander la validation" %}
+                    </a>
+                </li>
+            {% endif %}
         {% else %}
             {% if not content.is_validation %}
                 <li>

--- a/templates/tutorialv2/view/content.html
+++ b/templates/tutorialv2/view/content.html
@@ -313,7 +313,7 @@
                 {% if content.is_public %}
                     <li>
                         <a href="#unpublish" class="ico-after open-modal cross blue">{% trans "Dépublier" %}</a>
-                        <form action="{% url "zds.tutorial.views.invalid_tutorial" tutorial.pk %}" method="post" class="modal modal-small" id="unpublish">
+                        <form action="{% url "zds.tutorial.views.invalid_tutorial" content.pk %}" method="post" class="modal modal-small" id="unpublish">
                         	{% csrf_token %}
                             <p>
                                 {% blocktrans with tutorial_title=tutorial.title %}

--- a/templates/tutorialv2/view/content.html
+++ b/templates/tutorialv2/view/content.html
@@ -274,10 +274,27 @@
 
 {% block sidebar_blocks %}
     {% if perms.tutorial.change_tutorial %}
-        {#  more actions only for validators?!? #}
+
         <div class="mobile-menu-bloc mobile-all-links mobile-show-ico" data-title="Validation">
             <h3>{% trans "Validation" %}</h3>
             <ul>
+                <li>
+                    <a href="{% url "content:history-validation" content.pk content.slug %}" class="ico-after history blue">
+                        {% trans "Historique de validation" %}
+                    </a>
+                </li>
+                <li>
+                    <a  href="{% url 'mp-new' %}?{% for username in content.authors.all %}&amp;username={{ username }}{% endfor %}"
+                        class="ico-after cite blue"
+                    >
+                        {% trans "Envoyer un MP" %}
+                        {% if content.authors.all|length > 1 %}
+                            {% trans "aux auteurs" %}
+                        {% else %}
+                            à {% trans "l'auteur" %}
+                        {% endif %}
+                    </a>
+                </li>
                 <li>
                     {% if is_js %}
                         <a href="#js-activation" class="open-modal ico-after cross red">
@@ -292,6 +309,76 @@
                 <div id="js-activation" class="modal modal-small">
                     {% crispy formJs %}
                 </div>
+
+                {% if content.is_public %}
+                    <li>
+                        <a href="#unpublish" class="ico-after open-modal cross blue">{% trans "Dépublier" %}</a>
+                        <form action="{% url "zds.tutorial.views.invalid_tutorial" tutorial.pk %}" method="post" class="modal modal-small" id="unpublish">
+                        	{% csrf_token %}
+                            <p>
+                                {% blocktrans with tutorial_title=tutorial.title %}
+                                    Êtes-vous certains de vouloir <strong>dépublier</strong> le tutoriel "<em>{{ tutorial_title }}</em>"
+                                {% endblocktrans %}
+                            </p>
+                            <button type="submit">
+                                {% trans "Confirmer" %}
+                            </button>
+                        </form>
+                    </li>
+                {% endif %}
+
+                {% if content.in_validation %}
+                    {% if validation.is_pending %}
+                        <li>
+                            <form action="{% url "content:reserve-validation" validation.pk %}" method="post">
+                                {% csrf_token %}
+                                <button type="submit" class="ico-after lock blue">
+                                    {% trans "Réserver" %}
+                                </button>
+                            </form>
+                        </li>
+                    {% elif validation.is_pending_valid %}
+                        {% if validation.validator == user %}
+                            <li>
+                                <form action="{% url "content:reserve-validation" validation.pk %}" method="post">
+                                    {% csrf_token %}
+                                    <button type="submit" class="ico-after lock blue">
+                                        {% trans "Annuler la réservation" %}
+                                    </button>
+                                </form>
+                            </li>
+                            <li>
+                                <a href="#valid-publish" class="open-modal ico-after tick green">{% trans "Valider et publier" %}</a>
+                                <div class="modal modal-big" id="valid-publish">
+                                    {% crispy formValid %}
+                                </div>
+                            </li>
+                            <li>
+                                <a href="#reject" class="open-modal ico-after cross red">{% trans "Rejeter" %}</a>
+                                <div class="modal modal-big" id="reject">
+                                    {% crispy formReject %}
+                                </div>
+                            </li>
+                        {% else %}
+                            <li>
+                                <a href="#unreservation" class="open-modal ico-after lock blue">
+                                    {% blocktrans with validator_name=validation.validator.username %}
+                                        Réservé par <strong>{{ validator_name }}</strong>, le retirer
+                                    {% endblocktrans %}
+                                </a>
+                                <form action="{% url "content:reserve-validation" validation.pk %}" method="post" class="modal modal-small" id="unreservation">
+                                    {% csrf_token %}
+                                    <p>
+                                        {% trans "La validation de ce tutoriel est actuellement réservée par" %} {% include "misc/member_item.part.html" with member=validation.validator %}. {% trans "Êtes-vous certain de vouloir le retirer" %} ?
+                                    </p>
+                                    <button type="submit">
+                                        {% trans "Confirmer" %}
+                                    </button>
+                                </form>
+                            </li>
+                        {% endif %}
+                    {% endif %}
+                {% endif %}
             </ul>
         </div>
     {% endif %}

--- a/templates/tutorialv2/view/content.html
+++ b/templates/tutorialv2/view/content.html
@@ -322,18 +322,12 @@
 
                 {% if content.is_public %}
                     <li>
-                        <a href="#unpublish" class="ico-after open-modal cross blue">{% trans "Dépublier" %}</a>
-                        <form action="{% url "zds.tutorial.views.invalid_tutorial" content.pk %}" method="post" class="modal modal-small" id="unpublish">
-                        	{% csrf_token %}
-                            <p>
-                                {% blocktrans with tutorial_title=tutorial.title %}
-                                    Êtes-vous certains de vouloir <strong>dépublier</strong> le tutoriel "<em>{{ tutorial_title }}</em>"
-                                {% endblocktrans %}
-                            </p>
-                            <button type="submit">
-                                {% trans "Confirmer" %}
-                            </button>
-                        </form>
+                        <a href="#unpublish" class="ico-after open-modal cross blue">
+                            {% trans "Dépublier" %}
+                        </a>
+                        <div class="modal modal-big" id="unpublish">
+                            {% crispy formRevokeValidation %}
+                        </div>
                     </li>
                 {% endif %}
 

--- a/templates/tutorialv2/view/content.html
+++ b/templates/tutorialv2/view/content.html
@@ -38,7 +38,7 @@
         </h2>
     {% endif %}
 
-    {% if user.user in content.authors.all %}
+    {% if can_edit %}
         {% include 'tutorialv2/includes/tags_authors.part.html' with content=content add_author=True %}
     {% else %}
         {% include 'tutorialv2/includes/tags_authors.part.html' with content=content %}

--- a/templates/tutorialv2/view/content_online.html
+++ b/templates/tutorialv2/view/content_online.html
@@ -61,7 +61,7 @@
         </h2>
     {% endif %}
 
-    {% include 'tutorialv2/includes/tags_authors.part.html' with content=content %}
+    {% include 'tutorialv2/includes/tags_authors.part.html' with content=content online=True %}
 {% endblock %}
 
 

--- a/templates/tutorialv2/view/content_online.html
+++ b/templates/tutorialv2/view/content_online.html
@@ -1,0 +1,135 @@
+{% extends "tutorialv2/base_online.html" %}
+{% load emarkdown %}
+{% load profile %}
+{% load captureas %}
+{% load set %}
+{% load thumbnail %}
+{% load i18n %}
+
+
+{% block title %}
+    {{ content.title }}
+{% endblock %}
+
+
+
+{% block description %}
+    {{ content.description }}
+{% endblock %}
+
+
+
+{% block meta_image %}{% spaceless %}
+    {% if content.image %}
+        {{ content.image.physical.tutorial_illu.url }}
+    {% else %}
+        {{ block.super }}
+    {% endif %}
+{% endspaceless %}{% endblock %}
+
+
+
+{% block opengraph %}
+    {% include "tutorialv2/includes/opengraph.part.html" %}
+{% endblock %}
+
+
+
+{% block breadcrumb %}
+    <li>{{ content.title }}</li>
+{% endblock %}
+
+
+
+{% block headline %}
+    {% if content.licence %}
+        <span class="license" itemprop="license">
+            {{ content.licence }}
+        </span>
+    {% endif %}
+
+    <h1 {% if content.image %}class="illu"{% endif %} itemprop="name">
+        {% if content.image %}
+            <img src="{{ content.image.physical.tutorial_illu.url }}" alt="" itemprop="thumbnailUrl">
+        {% endif %}
+        {{ content.title }}
+    </h1>
+
+    {% if content.description %}
+        <h2 class="subtitle" itemprop="description">
+            {{ content.description }}
+        </h2>
+    {% endif %}
+
+    {% include 'tutorialv2/includes/tags_authors.part.html' with content=content %}
+{% endblock %}
+
+
+
+{% block content %}
+
+    {% if content.has_extracts %}
+        {{ content.get_content_online|safe }}
+    {% else %}
+
+        {% if content.introduction %}
+            {{ content.get_introduction_online|safe }}
+        {% endif %}
+
+        {% for child in content.children %}
+            {%  include "tutorialv2/includes/child_online.part.html" with child=child %}
+        {% endfor %}
+
+        <hr class="clearfix" />
+        <hr />
+
+        {% if content.conclusion %}
+            {{ content.get_conclusion_online|safe }}
+        {% endif %}
+
+    {% endif %}
+{% endblock %}
+
+
+
+{# content after stuffs !! (comments) #}
+
+
+
+{% block sidebar_blocks %}
+    {% include "tutorialv2/includes/summary.part.html" with online=True %}
+
+    {% if perms.tutorial.change_tutorial %}
+        <div class="mobile-menu-bloc mobile-all-links mobile-show-ico" data-title="Administration">
+            <h3>{% blocktrans %}Admin<span class="wide">istration</span>{% endblocktrans %}</h3>
+            <ul>
+                <li>
+                    <a href="{{ content.get_absolute_url }}" class="ico-after offline blue">
+                        {% trans "Version hors-ligne" %}
+                    </a>
+                </li>
+                <li>
+                    <a href="{% url "content:history-validation" content.pk content.slug %}" class="ico-after history blue">
+                        {% trans "Historique validation" %}
+                    </a>
+                </li>
+                <li>
+                    <a href="#unpublish" class="ico-after open-modal cross blue">
+                        {% trans "Dépublier" %}
+                    </a>
+                    <form action="{% url "zds.tutorial.views.invalid_tutorial" content.pk %}" method="post" class="modal modal-small" id="unpublish">
+                    	{% csrf_token %}
+                        <p>
+                            {% trans "Êtes-vous certains de vouloir dépublier le tutoriel" %} « <em>{{ tutorial.title }}</em> » ?
+                        </p>
+                        <button type="submit">
+                            {% trans "Confirmer" %}
+                        </button>
+                    </form>
+                </li>
+            </ul>
+        </div>
+    {% endif %}
+
+    {% include "misc/social_buttons.part.html" with link=content.get_absolute_url_online text=content.title %}
+{% endblock %}

--- a/templates/tutorialv2/view/content_online.html
+++ b/templates/tutorialv2/view/content_online.html
@@ -5,6 +5,7 @@
 {% load set %}
 {% load thumbnail %}
 {% load i18n %}
+{% load crispy_forms_tags %}
 
 
 {% block title %}
@@ -117,15 +118,9 @@
                     <a href="#unpublish" class="ico-after open-modal cross blue">
                         {% trans "Dépublier" %}
                     </a>
-                    <form action="{% url "zds.tutorial.views.invalid_tutorial" content.pk %}" method="post" class="modal modal-small" id="unpublish">
-                    	{% csrf_token %}
-                        <p>
-                            {% trans "Êtes-vous certains de vouloir dépublier le tutoriel" %} « <em>{{ tutorial.title }}</em> » ?
-                        </p>
-                        <button type="submit">
-                            {% trans "Confirmer" %}
-                        </button>
-                    </form>
+                    <div class="modal modal-big" id="unpublish">
+                        {% crispy formRevokeValidation %}
+                    </div>
                 </li>
             </ul>
         </div>

--- a/zds/settings.py
+++ b/zds/settings.py
@@ -441,7 +441,10 @@ ZDS_APP = {
         'repo_private_path': os.path.join(BASE_DIR, 'contents-private'),
         'repo_public_path': os.path.join(BASE_DIR, 'contents-public'),
         'max_tree_depth': 3,
-        'default_license_pk': 7
+        'default_license_pk': 7,
+        'content_per_page': 50,
+        'helps_per_page': 20,
+        'feed_length': 5
     },
     'forum': {
         'posts_per_page': 21,

--- a/zds/tutorial/factories.py
+++ b/zds/tutorial/factories.py
@@ -47,7 +47,7 @@ class BigTutorialFactory(factory.DjangoModelFactory):
 
         light = kwargs.pop('light', False)
         tuto = super(BigTutorialFactory, cls)._prepare(create, **kwargs)
-        path = tuto.get_repo_path()
+        path = tuto.get_path()
         real_content = content
         if light:
             real_content = content_light
@@ -144,8 +144,8 @@ class PartFactory(factory.DjangoModelFactory):
         if light:
             real_content = content_light
 
-        path = part.get_repo_path()
-        repo = Repo(part.tutorial.get_repo_path())
+        path = part.get_path()
+        repo = Repo(part.tutorial.get_path())
 
         if not os.path.isdir(path):
             os.makedirs(path, mode=0o777)
@@ -202,7 +202,7 @@ class ChapterFactory(factory.DjangoModelFactory):
         real_content = content
         if light:
             real_content = content_light
-        path = chapter.get_repo_path()
+        path = chapter.get_path()
 
         if not os.path.isdir(path):
             os.makedirs(path, mode=0o777)
@@ -235,25 +235,25 @@ class ChapterFactory(factory.DjangoModelFactory):
             chapter.save()
             f = open(
                 os.path.join(
-                    part.tutorial.get_repo_path(),
+                    part.tutorial.get_path(),
                     chapter.introduction),
                 "w")
             f.write(real_content.encode('utf-8'))
             f.close()
             f = open(
                 os.path.join(
-                    part.tutorial.get_repo_path(),
+                    part.tutorial.get_path(),
                     chapter.conclusion),
                 "w")
             f.write(real_content.encode('utf-8'))
             f.close()
             part.tutorial.save()
-            repo = Repo(part.tutorial.get_repo_path())
+            repo = Repo(part.tutorial.get_path())
 
             man = export_tutorial(part.tutorial)
             f = open(
                 os.path.join(
-                    part.tutorial.get_repo_path(),
+                    part.tutorial.get_path(),
                     'manifest.json'),
                 "w")
             f.write(

--- a/zds/tutorial/tests/tests.py
+++ b/zds/tutorial/tests/tests.py
@@ -1149,8 +1149,8 @@ class BigTutorialTests(TestCase):
                 'introduction': u"Expérimentation : edition d'introduction",
                 'conclusion': u"C'est terminé : edition de conlusion",
                 'msg_commit': u"Mise à jour de la partie",
-                "last_hash": compute_hash([os.path.join(p2.tutorial.get_repo_path(), p2.introduction),
-                                           os.path.join(p2.tutorial.get_repo_path(), p2.conclusion)])
+                "last_hash": compute_hash([os.path.join(p2.tutorial.get_path(), p2.introduction),
+                                           os.path.join(p2.tutorial.get_path(), p2.conclusion)])
             },
             follow=True)
         self.assertContains(response=result, text=u"Partie 2 : edition de titre")
@@ -1167,8 +1167,8 @@ class BigTutorialTests(TestCase):
                 'conclusion': u"Edition de conlusion",
                 'msg_commit': u"Mise à jour du chapitre",
                 "last_hash": compute_hash([
-                    os.path.join(c3.get_repo_path(), "introduction.md"),
-                    os.path.join(c3.get_repo_path(), "conclusion.md")])
+                    os.path.join(c3.get_path(), "introduction.md"),
+                    os.path.join(c3.get_path(), "conclusion.md")])
             },
             follow=True)
         self.assertContains(response=result, text=u"Chapitre 3 : edition de titre")
@@ -1185,8 +1185,8 @@ class BigTutorialTests(TestCase):
                 'introduction': u"Expérimentation : seconde edition d'introduction",
                 'conclusion': u"C'est terminé : seconde edition de conlusion",
                 'msg_commit': u"2nd Màj de la partie 2",
-                "last_hash": compute_hash([os.path.join(p2.tutorial.get_repo_path(), p2.introduction),
-                                           os.path.join(p2.tutorial.get_repo_path(), p2.conclusion)])
+                "last_hash": compute_hash([os.path.join(p2.tutorial.get_path(), p2.introduction),
+                                           os.path.join(p2.tutorial.get_path(), p2.conclusion)])
             },
             follow=True)
         self.assertContains(response=result, text=u"Partie 2 : seconde edition de titre")
@@ -1203,8 +1203,8 @@ class BigTutorialTests(TestCase):
                 'conclusion': u"Edition de conlusion",
                 'msg_commit': u"MàJ du chapitre 2",
                 "last_hash": compute_hash([
-                    os.path.join(c2.get_repo_path(), "introduction.md"),
-                    os.path.join(c2.get_repo_path(), "conclusion.md")])
+                    os.path.join(c2.get_path(), "introduction.md"),
+                    os.path.join(c2.get_path(), "conclusion.md")])
             },
             follow=True)
         self.assertContains(response=result, text=u"Chapitre 2 : edition de titre")
@@ -1218,7 +1218,7 @@ class BigTutorialTests(TestCase):
             {
                 'title': u"Extrait 2 : edition de titre",
                 'text': u"Agrume",
-                "last_hash": compute_hash([os.path.join(e2.get_repo_path())])
+                "last_hash": compute_hash([os.path.join(e2.get_path())])
             },
             follow=True)
         self.assertContains(response=result, text=u"Extrait 2 : edition de titre")
@@ -1665,8 +1665,8 @@ class BigTutorialTests(TestCase):
             },
             follow=False)
         p1 = Part.objects.last()
-        hash = compute_hash([os.path.join(p1.tutorial.get_repo_path(), p1.introduction),
-                             os.path.join(p1.tutorial.get_repo_path(), p1.conclusion)])
+        hash = compute_hash([os.path.join(p1.tutorial.get_path(), p1.introduction),
+                             os.path.join(p1.tutorial.get_path(), p1.conclusion)])
         self.client.post(
             reverse('zds.tutorial.views.edit_part') + '?partie={}'.format(p1.pk),
             {
@@ -1698,8 +1698,8 @@ class BigTutorialTests(TestCase):
             },
             follow=False)
         c1 = Chapter.objects.last()
-        hash = compute_hash([os.path.join(c1.get_repo_path(), "introduction.md"),
-                             os.path.join(c1.get_repo_path(), "conclusion.md")])
+        hash = compute_hash([os.path.join(c1.get_path(), "introduction.md"),
+                             os.path.join(c1.get_path(), "conclusion.md")])
         self.client.post(
             reverse('zds.tutorial.views.edit_chapter') + '?chapitre={}'.format(c1.pk),
             {
@@ -2671,8 +2671,8 @@ class BigTutorialTests(TestCase):
                 'introduction': u"Expérimentation : edition d'introduction",
                 'conclusion': u"C'est terminé : edition de conlusion",
                 'msg_commit': u"Changement de la partie",
-                "last_hash": compute_hash([os.path.join(part.tutorial.get_repo_path(), part.introduction),
-                                           os.path.join(part.tutorial.get_repo_path(), part.conclusion)])
+                "last_hash": compute_hash([os.path.join(part.tutorial.get_path(), part.introduction),
+                                           os.path.join(part.tutorial.get_path(), part.conclusion)])
             },
             follow=True)
         self.assertEqual(result.status_code, 200)
@@ -2709,8 +2709,8 @@ class BigTutorialTests(TestCase):
                 'conclusion': u"Edition de conlusion",
                 'msg_commit': u"MàJ du chapitre 2 : le respect des agrumes sur ZdS",
                 "last_hash": compute_hash([
-                    os.path.join(chapter.get_repo_path(), "introduction.md"),
-                    os.path.join(chapter.get_repo_path(), "conclusion.md")])
+                    os.path.join(chapter.get_path(), "introduction.md"),
+                    os.path.join(chapter.get_path(), "conclusion.md")])
             },
             follow=True)
         self.assertEqual(result.status_code, 200)
@@ -2741,7 +2741,7 @@ class BigTutorialTests(TestCase):
             {
                 'title': u"Extrait 2 : edition de titre",
                 'text': u"On ne torture pas les agrumes !",
-                "last_hash": compute_hash([os.path.join(extract.get_repo_path())])
+                "last_hash": compute_hash([os.path.join(extract.get_path())])
             },
             follow=True)
         self.assertEqual(result.status_code, 200)
@@ -3130,7 +3130,7 @@ class MiniTutorialTests(TestCase):
         tuto = Tutorial.objects.get(pk=self.minituto.pk)
         self.assertEqual(Extract.objects.all().count(), 1)
         intro_path = os.path.join(tuto.get_path(), "introduction.md")
-        extract_path = Extract.objects.first().get_repo_path()
+        extract_path = Extract.objects.first().get_path()
         self.assertNotEqual(intro_path, extract_path)
         self.assertTrue(os.path.isfile(intro_path))
         self.assertTrue(os.path.isfile(extract_path))
@@ -3154,7 +3154,7 @@ class MiniTutorialTests(TestCase):
         tuto = Tutorial.objects.get(pk=self.minituto.pk)
         self.assertEqual(Extract.objects.all().count(), 1)
         ccl_path = os.path.join(tuto.get_path(), "conclusion.md")
-        extract_path = Extract.objects.first().get_repo_path()
+        extract_path = Extract.objects.first().get_path()
         self.assertNotEqual(ccl_path, extract_path)
         self.assertTrue(os.path.isfile(ccl_path))
         self.assertTrue(os.path.isfile(extract_path))
@@ -4086,7 +4086,7 @@ class MiniTutorialTests(TestCase):
             {
                 'title': u"Extrait 2 : edition de titre",
                 'text': u"Edition d'introduction",
-                "last_hash": compute_hash([e2.get_repo_path()])
+                "last_hash": compute_hash([e2.get_path()])
             },
             follow=True)
         self.assertEqual(result.status_code, 200)
@@ -4549,7 +4549,7 @@ class MiniTutorialTests(TestCase):
             {
                 'title': u"Un autre titre",
                 'text': u"j'ai changé d'avis, je vais mettre un sapin synthétique",
-                "last_hash": compute_hash([extract.get_repo_path()])
+                "last_hash": compute_hash([extract.get_path()])
             },
             follow=True)
         self.assertEqual(result.status_code, 200)

--- a/zds/tutorialv2/admin.py
+++ b/zds/tutorialv2/admin.py
@@ -2,9 +2,10 @@
 
 from django.contrib import admin
 
-from .models import PublishableContent, Validation, ContentReaction
+from .models import PublishableContent, Validation, ContentReaction, PublishedContent
 
 
 admin.site.register(PublishableContent)
+admin.site.register(PublishedContent)
 admin.site.register(Validation)
 admin.site.register(ContentReaction)

--- a/zds/tutorialv2/factories.py
+++ b/zds/tutorialv2/factories.py
@@ -10,14 +10,14 @@ from zds.tutorialv2.models import PublishableContent, Validation, ContentReactio
 from zds.utils.models import SubCategory, Licence
 from zds.gallery.factories import GalleryFactory, UserGalleryFactory
 
-text_content = u'Ceci est un texte bidon'
+text_content = u'Ceci est un texte bidon, **avec markown**'
 
 
 class PublishableContentFactory(factory.DjangoModelFactory):
     FACTORY_FOR = PublishableContent
 
-    title = factory.Sequence(lambda n: 'Mon Tutoriel No{0}'.format(n))
-    description = factory.Sequence(lambda n: 'Description du Tutoriel No{0}'.format(n))
+    title = factory.Sequence(lambda n: 'Mon contenu No{0}'.format(n))
+    description = factory.Sequence(lambda n: 'Description du contenu No{0}'.format(n))
     type = 'TUTORIAL'
     creation_date = datetime.now()
 

--- a/zds/tutorialv2/forms.py
+++ b/zds/tutorialv2/forms.py
@@ -476,6 +476,19 @@ class AskValidationForm(forms.Form):
                 type='submit')
         )
 
+    def clean(self):
+        cleaned_data = super(AskValidationForm, self).clean()
+
+        text = cleaned_data.get('text')
+
+        if text is None or text.strip() == '':
+            self._errors['text'] = self.error_class(
+                [_(u'Vous devez écrire une réponse !')])
+            if 'text' in cleaned_data:
+                del cleaned_data['text']
+
+        return cleaned_data
+
 
 class AcceptValidationForm(forms.Form):
 
@@ -483,7 +496,7 @@ class AcceptValidationForm(forms.Form):
 
     text = forms.CharField(
         label='',
-        required=False,
+        required=True,
         widget=forms.Textarea(
             attrs={
                 'placeholder': _(u'Commentaire de publication.'),
@@ -543,7 +556,7 @@ class RejectValidationForm(forms.Form):
 
     text = forms.CharField(
         label='',
-        required=False,
+        required=True,
         widget=forms.Textarea(
             attrs={
                 'placeholder': _(u'Commentaire de rejet.'),
@@ -552,15 +565,13 @@ class RejectValidationForm(forms.Form):
         )
     )
 
-    validation = None
-
     def __init__(self, *args, **kwargs):
 
-        self.validation = kwargs.pop('instance', None)
+        validation = kwargs.pop('instance', None)
 
         super(RejectValidationForm, self).__init__(*args, **kwargs)
         self.helper = FormHelper()
-        self.helper.form_action = reverse('content:reject-validation', kwargs={'pk': self.validation.pk})
+        self.helper.form_action = reverse('content:reject-validation', kwargs={'pk': validation.pk})
         self.helper.form_method = 'post'
 
         self.helper.layout = Layout(
@@ -570,6 +581,64 @@ class RejectValidationForm(forms.Form):
                     _(u'Rejeter'),
                     type='submit'))
         )
+
+    def clean(self):
+        cleaned_data = super(RejectValidationForm, self).clean()
+
+        text = cleaned_data.get('text')
+
+        if text is None or text.strip() == '':
+            self._errors['text'] = self.error_class(
+                [_(u'Vous devez écrire une réponse !')])
+            if 'text' in cleaned_data:
+                del cleaned_data['text']
+
+        return cleaned_data
+
+
+class RevokeValidationForm(forms.Form):
+
+    version = forms.CharField(widget=forms.HiddenInput())
+
+    text = forms.CharField(
+        label='',
+        required=True,
+        widget=forms.Textarea(
+            attrs={
+                'placeholder': _(u'Pourquoi dépublier ce contenu ?'),
+                'rows': '6'
+            }
+        )
+    )
+
+    def __init__(self, *args, **kwargs):
+        content = kwargs.pop('instance', None)
+
+        super(RevokeValidationForm, self).__init__(*args, **kwargs)
+        self.helper = FormHelper()
+        self.helper.form_action = reverse('content:revoke-validation', kwargs={'pk': content.pk, 'slug': content.slug})
+        self.helper.form_method = 'post'
+
+        self.helper.layout = Layout(
+            CommonLayoutModalText(),
+            Field('version'),
+            StrictButton(
+                _(u'Dépublier'),
+                type='submit')
+        )
+
+    def clean(self):
+        cleaned_data = super(RevokeValidationForm, self).clean()
+
+        text = cleaned_data.get('text')
+
+        if text is None or text.strip() == '':
+            self._errors['text'] = self.error_class(
+                [_(u'Vous devez écrire une réponse !')])
+            if 'text' in cleaned_data:
+                del cleaned_data['text']
+
+        return cleaned_data
 
 
 class JsFiddleActivationForm(forms.Form):

--- a/zds/tutorialv2/forms.py
+++ b/zds/tutorialv2/forms.py
@@ -477,7 +477,7 @@ class AskValidationForm(forms.Form):
         )
 
 
-class AcceptContentForm(forms.Form):
+class AcceptValidationForm(forms.Form):
 
     validation = None
 
@@ -512,7 +512,7 @@ class AcceptContentForm(forms.Form):
 
         self.validation = kwargs.pop('instance', None)
 
-        super(AcceptContentForm, self).__init__(*args, **kwargs)
+        super(AcceptValidationForm, self).__init__(*args, **kwargs)
 
         self.helper = FormHelper()
         self.helper.form_action = reverse('content:accept-validation', kwargs={'pk': self.validation.pk})
@@ -526,7 +526,7 @@ class AcceptContentForm(forms.Form):
         )
 
     def clean(self):
-        cleaned_data = super(AcceptContentForm, self).clean()
+        cleaned_data = super(AcceptValidationForm, self).clean()
 
         text = cleaned_data.get('text')
 
@@ -539,7 +539,7 @@ class AcceptContentForm(forms.Form):
         return cleaned_data
 
 
-class RejectForm(forms.Form):
+class RejectValidationForm(forms.Form):
 
     text = forms.CharField(
         label='',
@@ -552,22 +552,23 @@ class RejectForm(forms.Form):
         )
     )
 
-    version = forms.CharField(widget=forms.HiddenInput(), required=True)
+    validation = None
 
     def __init__(self, *args, **kwargs):
-        super(RejectForm, self).__init__(*args, **kwargs)
+
+        self.validation = kwargs.pop('instance', None)
+
+        super(RejectValidationForm, self).__init__(*args, **kwargs)
         self.helper = FormHelper()
-        self.helper.form_action = reverse('zds.tutorial.views.reject_tutorial')
+        self.helper.form_action = reverse('content:reject-validation', kwargs={'pk': self.validation.pk})
         self.helper.form_method = 'post'
 
         self.helper.layout = Layout(
             CommonLayoutModalText(),
-            Field('version'),
             ButtonHolder(
                 StrictButton(
                     _(u'Rejeter'),
-                    type='submit'),),
-            Hidden('tutorial', '{{ tutorial.pk }}')
+                    type='submit'))
         )
 
 

--- a/zds/tutorialv2/migrations/0002_auto_20150417_0445.py
+++ b/zds/tutorialv2/migrations/0002_auto_20150417_0445.py
@@ -1,0 +1,43 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import models, migrations
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('tutorialv2', '0001_initial'),
+    ]
+
+    operations = [
+        migrations.CreateModel(
+            name='PublishedContent',
+            fields=[
+                ('id', models.AutoField(verbose_name='ID', serialize=False, auto_created=True, primary_key=True)),
+                ('content_type', models.CharField(db_index=True, max_length=10, verbose_name=b'Type de contenu', choices=[(b'TUTORIAL', b'Tutoriel'), (b'ARTICLE', b'Article')])),
+                ('content_public_slug', models.CharField(max_length=80, verbose_name=b'Slug du contenu publi\xc3\xa9')),
+                ('content_pk', models.IntegerField(verbose_name=b'Pk du contenu publi\xc3\xa9', db_index=True)),
+                ('publication_date', models.DateTimeField(db_index=True, null=True, verbose_name=b'Date de publication', blank=True)),
+                ('sha_public', models.CharField(db_index=True, max_length=80, null=True, verbose_name=b'Sha1 de la version publique', blank=True)),
+                ('content', models.ForeignKey(verbose_name=b'Contenu', to='tutorialv2.PublishableContent')),
+            ],
+            options={
+                'verbose_name': 'Contenu publi\xe9',
+                'verbose_name_plural': 'Contenus publi\xe9s',
+            },
+            bases=(models.Model,),
+        ),
+        migrations.AlterField(
+            model_name='validation',
+            name='comment_authors',
+            field=models.TextField(null=True, verbose_name=b"Commentaire de l'auteur", blank=True),
+            preserve_default=True,
+        ),
+        migrations.AlterField(
+            model_name='validation',
+            name='date_proposition',
+            field=models.DateTimeField(db_index=True, null=True, verbose_name=b'Date de proposition', blank=True),
+            preserve_default=True,
+        ),
+    ]

--- a/zds/tutorialv2/mixins.py
+++ b/zds/tutorialv2/mixins.py
@@ -232,6 +232,9 @@ class SingleOnlineContentDetailViewMixin(ContentTypeMixin, DetailView):
         except ObjectDoesNotExist:
             raise Http404
 
+        if obj is None:
+            raise Http404
+
         return obj
 
     def get(self, request, *args, **kwargs):

--- a/zds/tutorialv2/mixins.py
+++ b/zds/tutorialv2/mixins.py
@@ -205,9 +205,11 @@ class SingleOnlineContentDetailViewMixin(ContentTypeMixin, DetailView):
     - by rewriting `get()`, that:
         * `self.object` contains the result of `get_object()` (as it must be if `get()` was not rewritten)
         * `self.versioned_object` contains a PublicContent object
+        * self.public_content_object contains a PublishedContent object
     - by surcharging `get_context_data()`, that
         * context['content'] contains the
         * context['can_edit'] is set
+        * context['public_object'] is set
     """
 
     model = PublishedContent
@@ -246,6 +248,7 @@ class SingleOnlineContentDetailViewMixin(ContentTypeMixin, DetailView):
         context = super(SingleOnlineContentDetailViewMixin, self).get_context_data(**kwargs)
 
         context['content'] = self.versioned_object
+        context['public_object'] = self.public_content_object
         context['can_edit'] = self.request.user in self.object.authors.all()
 
         return context

--- a/zds/tutorialv2/mixins.py
+++ b/zds/tutorialv2/mixins.py
@@ -1,10 +1,12 @@
 from django.views.generic import View
 
-from django.core.exceptions import PermissionDenied
+from django.core.exceptions import PermissionDenied, ObjectDoesNotExist
 from django.http import Http404, HttpResponse
 from django.shortcuts import get_object_or_404
 from django.views.generic import DetailView, FormView
-from zds.tutorialv2.models import PublishableContent
+from django.utils.translation import ugettext as _
+
+from zds.tutorialv2.models import PublishableContent, PublishedContent
 
 
 class SingleContentViewMixin(object):
@@ -166,6 +168,85 @@ class SingleContentDetailViewMixin(SingleContentViewMixin, DetailView):
 
         if self.sha != self.object.sha_draft:
             context["version"] = self.sha
+
+        return context
+
+
+class ContentTypeMixin(object):
+    """This class deals with the type of contents and fill context according to that"""
+
+    content_type = None
+
+    def get_context_data(self, **kwargs):
+        context = super(ContentTypeMixin, self).get_context_data(**kwargs)
+
+        v_type_name = _(u'contenu')
+        v_type_name_plural = _(u'contenus')
+
+        if self.content_type == 'ARTICLE':
+            v_type_name = _(u'article')
+            v_type_name_plural = _(u'articles')
+
+        if self.content_type == 'TUTORIAL':
+            v_type_name = _(u'tutoriel')
+            v_type_name_plural = _(u'tutoriels')
+
+        context['content_type'] = self.content_type
+        context['verbose_type_name'] = v_type_name
+        context['verbose_type_name_plural'] = v_type_name_plural
+
+        return context
+
+
+class SingleOnlineContentDetailViewMixin(ContentTypeMixin, DetailView):
+    """
+    This enhanced DetailView ensure,
+
+    - by rewriting `get()`, that:
+        * `self.object` contains the result of `get_object()` (as it must be if `get()` was not rewritten)
+        * `self.versioned_object` contains a PublicContent object
+    - by surcharging `get_context_data()`, that
+        * context['content'] contains the
+        * context['can_edit'] is set
+    """
+
+    model = PublishedContent
+
+    object = None
+    public_content_object = None
+    versioned_object = None
+
+    def get_object(self, queryset=None):
+        pk = self.kwargs.pop('pk', None)
+        slug = self.kwargs.pop('slug', '')
+
+        try:
+            obj = PublishedContent.objects\
+                .filter(content_pk=pk, content_public_slug=slug, content_type=self.content_type)\
+                .prefetch_related('content')\
+                .prefetch_related("content__authors")\
+                .prefetch_related("content__subcategory")\
+                .first()
+        except ObjectDoesNotExist:
+            raise Http404
+
+        return obj
+
+    def get(self, request, *args, **kwargs):
+        self.public_content_object = self.get_object()
+        self.object = self.public_content_object.content
+
+        self.versioned_object = self.object.load_version_or_404(sha=self.public_content_object.sha_public,
+                                                                public=self.public_content_object)
+
+        context = self.get_context_data(object=self.object)
+        return self.render_to_response(context)
+
+    def get_context_data(self, **kwargs):
+        context = super(SingleOnlineContentDetailViewMixin, self).get_context_data(**kwargs)
+
+        context['content'] = self.versioned_object
+        context['can_edit'] = self.request.user in self.object.authors.all()
 
         return context
 

--- a/zds/tutorialv2/models.py
+++ b/zds/tutorialv2/models.py
@@ -1591,9 +1591,21 @@ class PublishedContent(models.Model):
     def get_prod_path(self):
         return os.path.join(settings.ZDS_APP['content']['repo_public_path'], self.content_public_slug)
 
-    def get_absolute_url_public(self):
-        # TODO: manage type (article:view or tutorial:view !!)
+    def get_absolute_url_online(self):
+        """reversed_ = ''
+
+        if self.is_article():
+            reversed_ = 'article'
+        elif self.is_tutorial():
+            reversed_ = 'tutorial'"""
+
         return reverse('content:view', kwargs={'pk': self.content_pk, 'slug': self.content_public_slug})
+
+    def is_article(self):
+        return self.content_type == "ARTICLE"
+
+    def is_tutorial(self):
+        return self.content_type == "TUTORIAL"
 
 
 class ContentReaction(Comment):
@@ -1666,7 +1678,7 @@ class Validation(models.Model):
         default='PENDING')
 
     def __unicode__(self):
-        return self.content.title
+        return _(u'Validation de « {} »').format(self.content.title)
 
     def is_pending(self):
         """Check if the validation is pending

--- a/zds/tutorialv2/models.py
+++ b/zds/tutorialv2/models.py
@@ -102,8 +102,8 @@ class Container:
         return u'<Conteneur \'{}\'>'.format(self.title)
 
     def has_extracts(self):
-        """
-        Note : this function rely on the fact that the children can only be of one type.
+        """Note : this function rely on the fact that the children can only be of one type.
+
         :return: `True` if the container has extract as children, `False` otherwise.
         """
         if len(self.children) == 0:
@@ -301,15 +301,20 @@ class Container:
         return os.path.join(base, self.slug)
 
     def get_prod_path(self):
-        """Get the physical path to the public version of the container.
-        Note: this function rely on the fact that the top container is VersionedContainer.
+        """Get the physical path to the public version of the container. If the container have extracts, then it
+        returns the final HTML file.
 
         :return: physical path
         """
         base = ''
         if self.parent:
             base = self.parent.get_prod_path()
-        return os.path.join(base, self.slug)
+        path = os.path.join(base, self.slug)
+
+        if self.has_extracts():
+            path += '.html'
+
+        return path
 
     def get_absolute_url(self):
         """
@@ -933,12 +938,17 @@ class VersionedContent(Container):
             return os.path.join(settings.ZDS_APP['content']['repo_private_path'], slug)
 
     def get_prod_path(self):
-        """
-        Get the physical path to the public version of the content
+        """Get the physical path to the public version of the content. If it has extract (so, if its a mini-tutorial or
+        an article), return the HTML file.
 
         :return: physical path
         """
-        return os.path.join(settings.ZDS_APP['content']['repo_public_path'], self.slug)
+        path = os.path.join(settings.ZDS_APP['content']['repo_public_path'], self.slug)
+
+        if self.has_extracts():
+            path = os.path.join(path, self.slug + '.html')
+
+        return path
 
     def get_list_of_chapters(self):
         """
@@ -1578,7 +1588,7 @@ class PublishedContent(models.Model):
     def __unicode__(self):
         return _('Version publique de "{}"').format(self.content.title)
 
-    def get_path(self):
+    def get_prod_path(self):
         return os.path.join(settings.ZDS_APP['content']['repo_public_path'], self.content_public_slug)
 
     def get_absolute_url_public(self):

--- a/zds/tutorialv2/models.py
+++ b/zds/tutorialv2/models.py
@@ -322,6 +322,16 @@ class Container:
         """
         return self.top_container().get_absolute_url() + self.get_path(relative=True) + '/'
 
+    def get_absolute_url_online(self):
+        base = ''
+
+        if self.parent:
+            base = self.parent.get_absolute_url_online()
+
+        base += self.slug + '/'
+
+        return base
+
     def get_edit_url(self):
         """
         :return: url to edit the container
@@ -367,6 +377,22 @@ class Container:
         if self.conclusion:
             return get_blob(self.top_container().repository.commit(self.top_container().current_version).tree,
                             self.conclusion)
+
+    def get_introduction_online(self):
+        if self.introduction:
+            path = os.path.join(self.top_container().get_prod_path(), self.introduction)
+            if os.path.isfile(path):
+                return open(path, 'r').read()
+
+    def get_conclusion_online(self):
+        if self.conclusion:
+            path = os.path.join(self.top_container().get_prod_path(), self.conclusion)
+            if os.path.isfile(path):
+                return open(path, 'r').read()
+
+    def get_content_online(self):
+        if os.path.isfile(self.get_prod_path()):
+            return open(self.get_prod_path(), 'r').read()
 
     def repo_update(self, title, introduction, conclusion, commit_message='', do_commit=True):
         """Update the container information and commit them into the repository
@@ -837,6 +863,8 @@ class VersionedContent(Container):
     slug_repository = ''
     repository = None
 
+    PUBLIC = False  # this variable is set to true when the VersionedContent is created from the public repository
+
     # Metadata from json :
     description = ''
     type = ''
@@ -909,9 +937,15 @@ class VersionedContent(Container):
 
     def get_absolute_url_online(self):
         """
-        :return: the url to access the tutorial when online
+        :return: the url to access the content when online
         """
-        return reverse('zds.tutorialv2.views.view_tutorial_online', args=[self.slug])
+        _reversed = ''
+
+        if self.is_article:
+            _reversed = 'article'
+        elif self.is_tutorial:
+            _reversed = 'tutorial'
+        return reverse(_reversed + ':view', kwargs={'pk': self.pk, 'slug': self.slug})
 
     def get_absolute_url_beta(self):
         """
@@ -1052,18 +1086,23 @@ class BadManifestError(Exception):
         self.message = reason
 
 
-def get_content_from_json(json, sha, slug_last_draft):
+def get_content_from_json(json, sha, slug_last_draft, public=False):
     """
     Transform the JSON formated data into `VersionedContent`
     :param json: JSON data from a `manifest.json` file
     :param sha: version
-    :return: a `VersionedContent` with all the information retrieved from JSON
+    :param public: the function will fill a PublicContent instead of a VersionedContent if `True`
+    :return: a Public/VersionedContent with all the information retrieved from JSON
     """
     # TODO: should definitely be static
 
     if 'version' in json and json['version'] == 2:
         # create and fill the container
-        versioned = VersionedContent(sha, 'TUTORIAL', json['title'], json['slug'], slug_last_draft)
+        if not public:
+            versioned = VersionedContent(sha, 'TUTORIAL', json['title'], json['slug'], slug_last_draft)
+        else:
+            versioned = PublicContent(sha, 'TUTORIAL', json['title'], json['slug'])
+
         # fill metadata :
         if 'description' in json:
             versioned.description = json['description']
@@ -1091,7 +1130,12 @@ def get_content_from_json(json, sha, slug_last_draft):
             _type = "TUTORIAL"
         else:
             _type = "ARTICLE"
-        versioned = VersionedContent(sha, _type, slug_last_draft, slug_last_draft)
+
+        if not public:
+            versioned = VersionedContent(sha, _type, json['title'], slug_last_draft)
+        else:
+            versioned = PublicContent(sha, _type, json['title'], slug_last_draft)
+
         if 'description' in json:
             versioned.description = json['description']
         if "introduction" in json:
@@ -1109,7 +1153,7 @@ def fill_containers_from_json(json_sub, parent):
     :param json_sub: dictionary from "manifest.json"
     :param parent: the container to fill
     """
-    # TODO should be static function of `VersionedContent` ?!ge
+    # TODO should be static function of `VersionedContent` ?!
     if 'children' in json_sub:
         for child in json_sub['children']:
             if child['object'] == 'container':
@@ -1133,10 +1177,13 @@ def fill_containers_from_json(json_sub, parent):
                 except KeyError:
                     pass
                 new_extract = Extract(child['title'], slug)
-                new_extract.text = child['text']
-                parent.add_extract(new_extract, generate_slug=(slug == ''))
+
+                if 'text' in child:
+                    new_extract.text = child['text']
+
+                parent.add_extract(new_extract, generate_slug=(slug != ''))
             else:
-                raise BadManifestError(_('Type d\'objet inconnu :') + child['object'])
+                raise BadManifestError(_(u'Type d\'objet inconnu : {}').format(child['object']))
 
 
 def init_new_repo(db_object, introduction_text, conclusion_text, commit_message='', do_commit=True):
@@ -1184,6 +1231,25 @@ def init_new_repo(db_object, introduction_text, conclusion_text, commit_message=
         db_object.save()
 
     return versioned_content
+
+
+class PublicContent(VersionedContent):
+    """This is the public version of a VersionedContent, created from public repository
+    """
+
+    def __init__(self, current_version, _type, title, slug):
+        """ This initialisation function avoid the loading of the Git repository
+
+        :param current_version: version of the content
+        :param _type: either "TUTORIAL" or "ARTICLE"
+        :param title: title of the content
+        :param slug: slug of the content
+        """
+
+        Container.__init__(self, title, slug)
+        self.current_version = current_version
+        self.type = _type
+        self.PUBLIC = True  # this is a public version
 
 
 def get_commit_author():
@@ -1366,12 +1432,13 @@ class PublishableContent(models.Model):
         """
         return self.type == 'TUTORIAL'
 
-    def load_version_or_404(self, sha=None, public=False):
+    def load_version_or_404(self, sha=None, public=None):
         """Using git, load a specific version of the content. if `sha` is `None`, the draft/public version is used (if
         `public` is `True`).
 
         :param sha: version
-        :param public: if `True`, use `sha_public` instead of `sha_draft` if `sha` is `None`
+        :param public: if set with the right object, return the public version
+        :type public: PublishedContent
         :raise Http404: if sha is not None and related version could not be found
         :return: the versioned content
         """
@@ -1380,17 +1447,21 @@ class PublishableContent(models.Model):
         except (BadObject, IOError):
             raise Http404
 
-    def load_version(self, sha=None, public=False):
+    def load_version(self, sha=None, public=None):
         """Using git, load a specific version of the content. if `sha` is `None`, the draft/public version is used (if
         `public` is `True`).
         .. attention::
             for practical reason, the returned object is filled with information from DB.
 
         :param sha: version
-        :param public: if `True`, use `sha_public` instead of `sha_draft` if `sha` is `None`
+        :param public: if set with the right object, return the public version
+        :type public: PublishedContent
         :raise BadObject: if sha is not None and related version could not be found
+        :raise IOError: if the path to the repository is wrong
+        :raise NotAPublicVersion: if the sha does not correspond to a public version
         :return: the versioned content
         """
+
         # load the good manifest.json
         if sha is None:
             if not public:
@@ -1398,17 +1469,33 @@ class PublishableContent(models.Model):
             else:
                 sha = self.sha_public
 
-        path = self.get_repo_path()
+        if public and isinstance(public, PublishedContent):  # use the public (altered and not versioned) repository
+            path = public.get_prod_path()
+            slug = public.content_public_slug
 
-        if not os.path.isdir(path):
-            raise IOError(path)
+            if not os.path.isdir(path):
+                raise IOError(path)
 
-        repo = Repo(path)
-        data = get_blob(repo.commit(sha).tree, 'manifest.json')
-        json = json_reader.loads(data)
-        versioned = get_content_from_json(json, sha, self.slug)
+            if sha != public.sha_public:
+                raise NotAPublicVersion
+
+            manifest = open(os.path.join(path, 'manifest.json'), 'r')
+            json = json_reader.loads(manifest.read())
+            versioned = get_content_from_json(json, public.sha_public, slug, public=True)
+
+        else:  # draft version, use the repository (slower, but allows manipulation)
+            path = self.get_repo_path()
+            slug = self.slug
+
+            if not os.path.isdir(path):
+                raise IOError(path)
+
+            repo = Repo(path)
+            data = get_blob(repo.commit(sha).tree, 'manifest.json')
+            json = json_reader.loads(data)
+            versioned = get_content_from_json(json, sha, self.slug)
+
         self.insert_data_in_versioned(versioned)
-
         return versioned
 
     def insert_data_in_versioned(self, versioned):
@@ -1562,6 +1649,13 @@ class PublishableContent(models.Model):
             shutil.rmtree(self.get_prod_path())
 
 
+class NotAPublicVersion(Exception):
+    """Exception raised when a given version is not a public version as it should be"""
+
+    def __init__(self, *args, **kwargs):
+        super(NotAPublicVersion, self).__init__(self, *args, **kwargs)
+
+
 class PublishedContent(models.Model):
     """A class that contains information on the published version of a content.
 
@@ -1592,14 +1686,17 @@ class PublishedContent(models.Model):
         return os.path.join(settings.ZDS_APP['content']['repo_public_path'], self.content_public_slug)
 
     def get_absolute_url_online(self):
-        """reversed_ = ''
+        """
+        :return: the URL of the published content
+        """
+        reversed_ = ''
 
         if self.is_article():
             reversed_ = 'article'
         elif self.is_tutorial():
-            reversed_ = 'tutorial'"""
+            reversed_ = 'tutorial'
 
-        return reverse('content:view', kwargs={'pk': self.content_pk, 'slug': self.content_public_slug})
+        return reverse(reversed_ + ':view', kwargs={'pk': self.content_pk, 'slug': self.content_public_slug})
 
     def is_article(self):
         return self.content_type == "ARTICLE"

--- a/zds/tutorialv2/tests/tests_models.py
+++ b/zds/tutorialv2/tests/tests_models.py
@@ -274,12 +274,15 @@ class ContentTests(TestCase):
         self.assertIsNotNone(new_part.introduction)
         self.assertIsNotNone(new_part.conclusion)
 
-    def extract_is_none(self):
+    def test_extract_is_none(self):
         """Test the case of a null extract"""
 
-        versioned = self.tuto.load_version()
+        article = PublishableContentFactory(type="ARTICLE")
+        versioned = article.load_version()
+
         given_title = u'Peu importe, en fait, ça compte peu'
         some_text = u'Disparaitra aussi vite que possible'
+
         # add a new extract with `None` for text
         version = versioned.repo_add_extract(given_title, None)
 
@@ -288,7 +291,7 @@ class ContentTests(TestCase):
         self.assertIsNone(new_extract.text)
 
         # it remains when loading the manifest !
-        versioned2 = self.tuto.load_version(sha=version)
+        versioned2 = article.load_version(sha=version)
         self.assertIsNotNone(versioned2)
         self.assertIsNone(versioned.children[-1].text)
 
@@ -296,7 +299,7 @@ class ContentTests(TestCase):
         self.assertIsNone(new_extract.text)
 
         # it remains
-        versioned2 = self.tuto.load_version(sha=version)
+        versioned2 = article.load_version(sha=version)
         self.assertIsNotNone(versioned2)
         self.assertIsNone(versioned.children[-1].text)
 
@@ -305,7 +308,7 @@ class ContentTests(TestCase):
         self.assertEqual(some_text, new_extract.get_text())
 
         # now it change
-        versioned2 = self.tuto.load_version(sha=version)
+        versioned2 = article.load_version(sha=version)
         self.assertIsNotNone(versioned2)
         self.assertIsNotNone(versioned.children[-1].text)
 
@@ -314,7 +317,7 @@ class ContentTests(TestCase):
         self.assertIsNone(new_extract.text)
 
         # it has changed
-        versioned2 = self.tuto.load_version(sha=version)
+        versioned2 = article.load_version(sha=version)
         self.assertIsNotNone(versioned2)
         self.assertIsNone(versioned.children[-1].text)
 

--- a/zds/tutorialv2/tests/tests_views.py
+++ b/zds/tutorialv2/tests/tests_views.py
@@ -15,7 +15,7 @@ from zds.settings import BASE_DIR
 from zds.member.factories import ProfileFactory, StaffProfileFactory
 from zds.tutorialv2.factories import PublishableContentFactory, ContainerFactory, ExtractFactory, LicenceFactory, \
     SubCategoryFactory
-from zds.tutorialv2.models import PublishableContent
+from zds.tutorialv2.models import PublishableContent, Validation, PublishedContent
 from zds.gallery.factories import GalleryFactory
 from zds.forum.factories import ForumFactory, CategoryFactory
 from zds.forum.models import Topic, Post
@@ -1912,6 +1912,774 @@ class ContentTests(TestCase):
             })
         )
         self.assertEqual(200, result.status_code)
+
+    def test_validation_workflow(self):
+        """test the different case of validation"""
+
+        text_validation = u'Valide moi ce truc, s\'il te plait'
+        source = u'http://example.com'  # thanks the IANA on that one ;-)
+        different_source = u'http://example.org'
+        text_accept = u'C\'est de la m***, mais ok, j\'accepte'
+        text_reject = u'Je refuse ce truc, arbitrairement !'
+
+        # let's create a medium-size tutorial
+        midsize_tuto = PublishableContentFactory(type='TUTORIAL')
+
+        midsize_tuto.authors.add(self.user_author)
+        midsize_tuto.gallery = GalleryFactory()
+        midsize_tuto.licence = self.licence
+        midsize_tuto.save()
+
+        # populate with 2 chapters (1 extract each)
+        midsize_tuto_draft = midsize_tuto.load_version()
+        chapter1 = ContainerFactory(parent=midsize_tuto_draft, db_objet=midsize_tuto)
+        ExtractFactory(container=chapter1, db_object=midsize_tuto)
+        chapter2 = ContainerFactory(parent=midsize_tuto_draft, db_objet=midsize_tuto)
+        ExtractFactory(container=chapter2, db_object=midsize_tuto)
+
+        # connect with author:
+        self.assertEqual(
+            self.client.login(
+                username=self.user_author.username,
+                password='hostel77'),
+            True)
+
+        # ask validation
+        self.assertEqual(Validation.objects.count(), 0)
+
+        result = self.client.post(
+            reverse('content:ask-validation', kwargs={'pk': midsize_tuto.pk, 'slug': midsize_tuto.slug}),
+            {
+                'text': text_validation,
+                'source': source,
+                'version': midsize_tuto_draft.current_version
+            },
+            follow=False)
+        self.assertEqual(result.status_code, 302)
+        self.assertEqual(Validation.objects.count(), 1)
+
+        self.assertEqual(PublishableContent.objects.get(pk=midsize_tuto.pk).source, source)  # source is set
+
+        validation = Validation.objects.get(content=midsize_tuto)
+        self.assertIsNotNone(validation)
+
+        self.assertEqual(validation.comment_authors, text_validation)
+        self.assertEqual(validation.version, midsize_tuto_draft.current_version)
+        self.assertEqual(validation.status, 'PENDING')
+
+        # ensure that author cannot publish himself
+        result = self.client.post(
+            reverse('content:reserve-validation', kwargs={'pk': validation.pk}),
+            {
+                'version': validation.version
+            },
+            follow=False)
+        self.assertEqual(result.status_code, 403)
+
+        result = self.client.post(
+            reverse('content:accept-validation', kwargs={'pk': validation.pk}),
+            {
+                'text': text_accept,
+                'is_major': True,
+                'source': u''
+            },
+            follow=False)
+        self.assertEqual(result.status_code, 403)
+
+        self.assertEqual(Validation.objects.filter(content=midsize_tuto).last().status, 'PENDING')
+
+        # logout, then login with guest
+        self.client.logout()
+
+        result = self.client.get(
+            reverse('content:view', kwargs={'pk': midsize_tuto.pk, 'slug': midsize_tuto.slug}) +
+            '?version=' + validation.version,
+            follow=False)
+        self.assertEqual(result.status_code, 302)  # no, public cannot access a tutorial in validation ...
+
+        self.assertEqual(
+            self.client.login(
+                username=self.user_guest.username,
+                password='hostel77'),
+            True)
+
+        result = self.client.get(
+            reverse('content:view', kwargs={'pk': midsize_tuto.pk, 'slug': midsize_tuto.slug}) +
+            '?version=' + validation.version,
+            follow=False)
+        self.assertEqual(result.status_code, 403)  # ... Same for guest ...
+
+        # then try with staff
+        self.client.logout()
+        self.assertEqual(
+            self.client.login(
+                username=self.user_staff.username,
+                password='hostel77'),
+            True)
+
+        result = self.client.get(
+            reverse('content:view', kwargs={'pk': midsize_tuto.pk, 'slug': midsize_tuto.slug}) +
+            '?version=' + validation.version,
+            follow=False)
+        self.assertEqual(result.status_code, 200)  # ... But staff can, obviously !
+
+        # reserve tuto:
+        result = self.client.post(
+            reverse('content:reserve-validation', kwargs={'pk': validation.pk}),
+            {
+                'version': validation.version
+            },
+            follow=False)
+        self.assertEqual(result.status_code, 302)
+
+        validation = Validation.objects.get(content=midsize_tuto)
+        self.assertEqual(validation.status, 'PENDING_V')
+        self.assertEqual(validation.validator, self.user_staff)
+
+        # unreserve
+        result = self.client.post(
+            reverse('content:reserve-validation', kwargs={'pk': validation.pk}),
+            {
+                'version': validation.version
+            },
+            follow=False)
+        self.assertEqual(result.status_code, 302)
+
+        validation = Validation.objects.get(content=midsize_tuto)
+        self.assertEqual(validation.status, 'PENDING')
+        self.assertEqual(validation.validator, None)
+
+        # re-reserve
+        result = self.client.post(
+            reverse('content:reserve-validation', kwargs={'pk': validation.pk}),
+            {
+                'version': validation.version
+            },
+            follow=False)
+        self.assertEqual(result.status_code, 302)
+
+        validation = Validation.objects.get(content=midsize_tuto)
+        self.assertEqual(validation.status, 'PENDING_V')
+        self.assertEqual(validation.validator, self.user_staff)
+
+        # let's modify the tutorial and ask for a new validation :
+        ExtractFactory(container=chapter2, db_object=midsize_tuto)
+        midsize_tuto = PublishableContent.objects.get(pk=midsize_tuto.pk)
+        midsize_tuto_draft = midsize_tuto.load_version()
+
+        result = self.client.post(
+            reverse('content:ask-validation', kwargs={'pk': midsize_tuto.pk, 'slug': midsize_tuto.slug}),
+            {
+                'text': text_validation,
+                'source': source,
+                'version': midsize_tuto_draft.current_version
+            },
+            follow=False)
+        self.assertEqual(result.status_code, 302)
+        self.assertEqual(Validation.objects.count(), 1)
+
+        # ... Therefore, the validation object is in pending status again
+        validation = Validation.objects.get(content=midsize_tuto)
+        self.assertEqual(validation.status, 'PENDING')
+        self.assertEqual(validation.validator, None)
+        self.assertEqual(validation.version, midsize_tuto_draft.current_version)
+
+        self.assertEqual(PublishableContent.objects.get(pk=midsize_tuto.pk).sha_validation,
+                         midsize_tuto_draft.current_version)
+
+        self.assertEqual(PrivateTopic.objects.last().author, self.user_staff)  # admin has received a PM
+
+        # re-re-reserve (!)
+        result = self.client.post(
+            reverse('content:reserve-validation', kwargs={'pk': validation.pk}),
+            {
+                'version': validation.version
+            },
+            follow=False)
+        self.assertEqual(result.status_code, 302)
+
+        validation = Validation.objects.get(content=midsize_tuto)
+        self.assertEqual(validation.status, 'PENDING_V')
+        self.assertEqual(validation.validator, self.user_staff)
+
+        # ensure that author cannot publish himself
+        self.assertEqual(
+            self.client.login(
+                username=self.user_author.username,
+                password='hostel77'),
+            True)
+
+        result = self.client.post(
+            reverse('content:accept-validation', kwargs={'pk': validation.pk}),
+            {
+                'text': text_accept,
+                'is_major': True,
+                'source': u''
+            },
+            follow=False)
+        self.assertEqual(result.status_code, 403)
+
+        self.assertEqual(Validation.objects.filter(content=midsize_tuto).last().status, 'PENDING_V')
+
+        # reject it with staff !
+        self.assertEqual(
+            self.client.login(
+                username=self.user_staff.username,
+                password='hostel77'),
+            True)
+
+        result = self.client.post(
+            reverse('content:reject-validation', kwargs={'pk': validation.pk}),
+            {
+                'text': text_reject
+            },
+            follow=False)
+        self.assertEqual(result.status_code, 302)
+
+        validation = Validation.objects.get(content=midsize_tuto)
+        self.assertEqual(validation.status, 'REJECT')
+        self.assertEqual(validation.comment_validator, text_reject)
+
+        self.assertIsNone(PublishableContent.objects.get(pk=midsize_tuto.pk).sha_validation)
+
+        self.assertEqual(PrivateTopic.objects.last().author, self.user_author)  # author has received a PM
+
+        # re-ask for validation
+        result = self.client.post(
+            reverse('content:ask-validation', kwargs={'pk': midsize_tuto.pk, 'slug': midsize_tuto.slug}),
+            {
+                'text': text_validation,
+                'source': source,
+                'version': midsize_tuto_draft.current_version
+            },
+            follow=False)
+        self.assertEqual(result.status_code, 302)
+        self.assertEqual(Validation.objects.filter(content=midsize_tuto).count(), 2)
+
+        # a new object is created !
+        validation = Validation.objects.filter(content=midsize_tuto).last()
+        self.assertEqual(validation.status, 'PENDING')
+        self.assertEqual(validation.validator, None)
+        self.assertEqual(validation.version, midsize_tuto_draft.current_version)
+
+        result = self.client.post(
+            reverse('content:reserve-validation', kwargs={'pk': validation.pk}),
+            {
+                'version': validation.version
+            },
+            follow=False)
+        self.assertEqual(result.status_code, 302)
+
+        validation = Validation.objects.filter(content=midsize_tuto).last()
+        self.assertEqual(validation.status, 'PENDING_V')
+        self.assertEqual(validation.validator, self.user_staff)
+        self.assertEqual(validation.version, midsize_tuto_draft.current_version)
+
+        # accept
+        result = self.client.post(
+            reverse('content:accept-validation', kwargs={'pk': validation.pk}),
+            {
+                'text': text_accept,
+                'is_major': True,
+                'source': different_source  # because ;)
+            },
+            follow=False)
+        self.assertEqual(result.status_code, 302)
+
+        validation = Validation.objects.filter(content=midsize_tuto).last()
+        self.assertEqual(validation.status, 'ACCEPT')
+        self.assertEqual(validation.comment_validator, text_accept)
+
+        self.assertIsNone(PublishableContent.objects.get(pk=midsize_tuto.pk).sha_validation)
+
+        self.assertEqual(PrivateTopic.objects.filter(author=self.user_author).count(), 2)
+        self.assertEqual(PrivateTopic.objects.last().author, self.user_author)  # author has received another PM
+
+        self.assertEqual(PublishedContent.objects.filter(content=midsize_tuto).count(), 1)
+        published = PublishedContent.objects.filter(content=midsize_tuto).first()
+
+        self.assertEqual(published.content.source, different_source)
+        self.assertEqual(published.content_public_slug, midsize_tuto_draft.slug)
+        self.assertTrue(os.path.exists(published.get_prod_path()))
+        # ... another test cover the file creation and so all, lets skip this part
+
+        # ensure that author cannot revoke his own publication
+        self.assertEqual(
+            self.client.login(
+                username=self.user_author.username,
+                password='hostel77'),
+            True)
+
+        result = self.client.post(
+            reverse('content:revoke-validation', kwargs={'pk': midsize_tuto.pk, 'slug': midsize_tuto.slug}),
+            {
+                'text': text_reject,
+                'version': published.sha_public
+            },
+            follow=False)
+        self.assertEqual(result.status_code, 403)
+        self.assertEqual(Validation.objects.filter(content=midsize_tuto).last().status, 'ACCEPT')
+
+        # revoke publication with staff
+        self.assertEqual(
+            self.client.login(
+                username=self.user_staff.username,
+                password='hostel77'),
+            True)
+
+        result = self.client.post(
+            reverse('content:revoke-validation', kwargs={'pk': midsize_tuto.pk, 'slug': midsize_tuto.slug}),
+            {
+                'text': text_reject,
+                'version': published.sha_public
+            },
+            follow=False)
+        self.assertEqual(result.status_code, 302)
+
+        validation = Validation.objects.filter(content=midsize_tuto).last()
+        self.assertEqual(validation.status, 'PENDING')
+
+        self.assertIsNotNone(PublishableContent.objects.get(pk=midsize_tuto.pk).sha_validation)
+
+        self.assertEqual(PublishedContent.objects.filter(content=midsize_tuto).count(), 0)
+        self.assertFalse(os.path.exists(published.get_prod_path()))
+
+        self.assertEqual(PrivateTopic.objects.filter(author=self.user_author).count(), 3)
+        self.assertEqual(PrivateTopic.objects.last().author, self.user_author)  # author has received another PM
+
+    def test_public_access(self):
+        """Test that everybody have access to a content after its publication"""
+
+        text_validation = u'Valide moi ce truc, please !'
+        text_publication = u'Aussi tôt dit, aussi tôt fait !'
+
+        # 1. Article:
+        article = PublishableContentFactory(type='ARTICLE')
+
+        article.authors.add(self.user_author)
+        article.gallery = GalleryFactory()
+        article.licence = self.licence
+        article.save()
+
+        # populate the article
+        article_draft = article.load_version()
+        ExtractFactory(container=article_draft, db_object=article)
+        ExtractFactory(container=article_draft, db_object=article)
+
+        # connect with author:
+        self.assertEqual(
+            self.client.login(
+                username=self.user_author.username,
+                password='hostel77'),
+            True)
+
+        # ask validation
+        self.assertEqual(Validation.objects.count(), 0)
+
+        result = self.client.post(
+            reverse('content:ask-validation', kwargs={'pk': article.pk, 'slug': article.slug}),
+            {
+                'text': text_validation,
+                'source': '',
+                'version': article_draft.current_version
+            },
+            follow=False)
+        self.assertEqual(result.status_code, 302)
+
+        # login with staff and publish
+        self.assertEqual(
+            self.client.login(
+                username=self.user_staff.username,
+                password='hostel77'),
+            True)
+
+        validation = Validation.objects.filter(content=article).last()
+
+        result = self.client.post(
+            reverse('content:reserve-validation', kwargs={'pk': validation.pk}),
+            {
+                'version': validation.version
+            },
+            follow=False)
+        self.assertEqual(result.status_code, 302)
+
+        # accept
+        result = self.client.post(
+            reverse('content:accept-validation', kwargs={'pk': validation.pk}),
+            {
+                'text': text_publication,
+                'is_major': True,
+                'source': u''
+            },
+            follow=False)
+        self.assertEqual(result.status_code, 302)
+
+        published = PublishedContent.objects.filter(content=article).first()
+        self.assertIsNotNone(published)
+
+        # test access to staff
+        result = self.client.get(reverse('article:view', kwargs={'pk': article.pk, 'slug': article_draft.slug}))
+        self.assertEqual(result.status_code, 200)
+
+        # test access to public
+        self.client.logout()
+        result = self.client.get(reverse('article:view', kwargs={'pk': article.pk, 'slug': article_draft.slug}))
+        self.assertEqual(result.status_code, 200)
+
+        # test access for guest user
+        self.assertEqual(
+            self.client.login(
+                username=self.user_guest.username,
+                password='hostel77'),
+            True)
+        result = self.client.get(reverse('article:view', kwargs={'pk': article.pk, 'slug': article_draft.slug}))
+        self.assertEqual(result.status_code, 200)
+
+        # 2. middle-size tutorial (just to test the access to chapters)
+        midsize_tuto = PublishableContentFactory(type='TUTORIAL')
+
+        midsize_tuto.authors.add(self.user_author)
+        midsize_tuto.gallery = GalleryFactory()
+        midsize_tuto.licence = self.licence
+        midsize_tuto.save()
+
+        # populate the midsize_tuto
+        midsize_tuto_draft = midsize_tuto.load_version()
+        chapter1 = ContainerFactory(parent=midsize_tuto_draft, db_object=midsize_tuto)
+        ExtractFactory(container=chapter1, db_object=midsize_tuto)
+
+        # connect with author:
+        self.assertEqual(
+            self.client.login(
+                username=self.user_author.username,
+                password='hostel77'),
+            True)
+
+        # ask validation
+        result = self.client.post(
+            reverse('content:ask-validation', kwargs={'pk': midsize_tuto.pk, 'slug': midsize_tuto.slug}),
+            {
+                'text': text_validation,
+                'source': '',
+                'version': midsize_tuto_draft.current_version
+            },
+            follow=False)
+        self.assertEqual(result.status_code, 302)
+
+        # login with staff and publish
+        self.assertEqual(
+            self.client.login(
+                username=self.user_staff.username,
+                password='hostel77'),
+            True)
+
+        validation = Validation.objects.filter(content=midsize_tuto).last()
+
+        result = self.client.post(
+            reverse('content:reserve-validation', kwargs={'pk': validation.pk}),
+            {
+                'version': validation.version
+            },
+            follow=False)
+        self.assertEqual(result.status_code, 302)
+
+        # accept
+        result = self.client.post(
+            reverse('content:accept-validation', kwargs={'pk': validation.pk}),
+            {
+                'text': text_publication,
+                'is_major': True,
+                'source': u''
+            },
+            follow=False)
+        self.assertEqual(result.status_code, 302)
+
+        published = PublishedContent.objects.filter(content=midsize_tuto).first()
+        self.assertIsNotNone(published)
+
+        # test access to staff
+        result = self.client.get(
+            reverse('tutorial:view', kwargs={'pk': midsize_tuto.pk, 'slug': midsize_tuto_draft.slug}))
+        self.assertEqual(result.status_code, 200)
+
+        result = self.client.get(
+            reverse('tutorial:view-container',
+                    kwargs={
+                        'pk': midsize_tuto.pk,
+                        'slug': midsize_tuto_draft.slug,
+                        'container_slug': chapter1.slug
+                    }))
+        self.assertEqual(result.status_code, 200)
+
+        # test access to public
+        self.client.logout()
+        result = self.client.get(
+            reverse('tutorial:view', kwargs={'pk': midsize_tuto.pk, 'slug': midsize_tuto_draft.slug}))
+        self.assertEqual(result.status_code, 200)
+
+        result = self.client.get(
+            reverse('tutorial:view-container',
+                    kwargs={
+                        'pk': midsize_tuto.pk,
+                        'slug': midsize_tuto_draft.slug,
+                        'container_slug': chapter1.slug
+                    }))
+        self.assertEqual(result.status_code, 200)
+
+        # test access for guest user
+        self.assertEqual(
+            self.client.login(
+                username=self.user_guest.username,
+                password='hostel77'),
+            True)
+        result = self.client.get(
+            reverse('tutorial:view', kwargs={'pk': midsize_tuto.pk, 'slug': midsize_tuto_draft.slug}))
+        self.assertEqual(result.status_code, 200)
+
+        result = self.client.get(
+            reverse('tutorial:view-container',
+                    kwargs={
+                        'pk': midsize_tuto.pk,
+                        'slug': midsize_tuto_draft.slug,
+                        'container_slug': chapter1.slug
+                    }))
+        self.assertEqual(result.status_code, 200)
+
+        # 3. a big tutorial (just to test the access to parts and chapters)
+        bigtuto = PublishableContentFactory(type='TUTORIAL')
+
+        bigtuto.authors.add(self.user_author)
+        bigtuto.gallery = GalleryFactory()
+        bigtuto.licence = self.licence
+        bigtuto.save()
+
+        # populate the bigtuto
+        bigtuto_draft = bigtuto.load_version()
+        part1 = ContainerFactory(parent=bigtuto_draft, db_object=bigtuto)
+        chapter1 = ContainerFactory(parent=part1, db_object=bigtuto)
+        ExtractFactory(container=chapter1, db_object=bigtuto)
+
+        # connect with author:
+        self.assertEqual(
+            self.client.login(
+                username=self.user_author.username,
+                password='hostel77'),
+            True)
+
+        # ask validation
+        result = self.client.post(
+            reverse('content:ask-validation', kwargs={'pk': bigtuto.pk, 'slug': bigtuto.slug}),
+            {
+                'text': text_validation,
+                'source': '',
+                'version': bigtuto_draft.current_version
+            },
+            follow=False)
+        self.assertEqual(result.status_code, 302)
+
+        # login with staff and publish
+        self.assertEqual(
+            self.client.login(
+                username=self.user_staff.username,
+                password='hostel77'),
+            True)
+
+        validation = Validation.objects.filter(content=bigtuto).last()
+
+        result = self.client.post(
+            reverse('content:reserve-validation', kwargs={'pk': validation.pk}),
+            {
+                'version': validation.version
+            },
+            follow=False)
+        self.assertEqual(result.status_code, 302)
+
+        # accept
+        result = self.client.post(
+            reverse('content:accept-validation', kwargs={'pk': validation.pk}),
+            {
+                'text': text_publication,
+                'is_major': True,
+                'source': u''
+            },
+            follow=False)
+        self.assertEqual(result.status_code, 302)
+
+        published = PublishedContent.objects.filter(content=bigtuto).first()
+        self.assertIsNotNone(published)
+
+        # test access to staff
+        result = self.client.get(
+            reverse('tutorial:view', kwargs={'pk': bigtuto.pk, 'slug': bigtuto_draft.slug}))
+        self.assertEqual(result.status_code, 200)
+
+        result = self.client.get(
+            reverse('tutorial:view-container',
+                    kwargs={
+                        'pk': bigtuto.pk,
+                        'slug': bigtuto_draft.slug,
+                        'container_slug': part1.slug
+                    }))
+        self.assertEqual(result.status_code, 200)
+
+        result = self.client.get(
+            reverse('tutorial:view-container',
+                    kwargs={
+                        'pk': bigtuto.pk,
+                        'slug': bigtuto_draft.slug,
+                        'parent_container_slug': part1.slug,
+                        'container_slug': chapter1.slug
+                    }))
+        self.assertEqual(result.status_code, 200)
+
+        # test access to public
+        self.client.logout()
+        result = self.client.get(
+            reverse('tutorial:view', kwargs={'pk': bigtuto.pk, 'slug': bigtuto_draft.slug}))
+        self.assertEqual(result.status_code, 200)
+
+        result = self.client.get(
+            reverse('tutorial:view-container',
+                    kwargs={
+                        'pk': bigtuto.pk,
+                        'slug': bigtuto_draft.slug,
+                        'container_slug': part1.slug
+                    }))
+        self.assertEqual(result.status_code, 200)
+
+        result = self.client.get(
+            reverse('tutorial:view-container',
+                    kwargs={
+                        'pk': bigtuto.pk,
+                        'slug': bigtuto_draft.slug,
+                        'parent_container_slug': part1.slug,
+                        'container_slug': chapter1.slug
+                    }))
+        self.assertEqual(result.status_code, 200)
+
+        # test access for guest user
+        self.assertEqual(
+            self.client.login(
+                username=self.user_guest.username,
+                password='hostel77'),
+            True)
+        result = self.client.get(
+            reverse('tutorial:view', kwargs={'pk': bigtuto.pk, 'slug': bigtuto_draft.slug}))
+        self.assertEqual(result.status_code, 200)
+
+        result = self.client.get(
+            reverse('tutorial:view-container',
+                    kwargs={
+                        'pk': bigtuto.pk,
+                        'slug': bigtuto_draft.slug,
+                        'container_slug': part1.slug
+                    }))
+        self.assertEqual(result.status_code, 200)
+
+        result = self.client.get(
+            reverse('tutorial:view-container',
+                    kwargs={
+                        'pk': bigtuto.pk,
+                        'slug': bigtuto_draft.slug,
+                        'parent_container_slug': part1.slug,
+                        'container_slug': chapter1.slug
+                    }))
+        self.assertEqual(result.status_code, 200)
+
+        # just for the fun of it, lets then revoke publication
+        self.assertEqual(
+            self.client.login(
+                username=self.user_staff.username,
+                password='hostel77'),
+            True)
+
+        result = self.client.post(
+            reverse('content:revoke-validation', kwargs={'pk': bigtuto.pk, 'slug': bigtuto.slug}),
+            {
+                'text': u'Pour le fun',
+                'version': bigtuto_draft.current_version
+            },
+            follow=False)
+        self.assertEqual(result.status_code, 302)
+
+        # now, let's get a whole bunch of good old fashioned 404 (and not 403 or 302 !!)
+        result = self.client.get(
+            reverse('tutorial:view', kwargs={'pk': bigtuto.pk, 'slug': bigtuto_draft.slug}))
+        self.assertEqual(result.status_code, 404)
+
+        result = self.client.get(
+            reverse('tutorial:view-container',
+                    kwargs={
+                        'pk': bigtuto.pk,
+                        'slug': bigtuto_draft.slug,
+                        'container_slug': part1.slug
+                    }))
+        self.assertEqual(result.status_code, 404)
+
+        result = self.client.get(
+            reverse('tutorial:view-container',
+                    kwargs={
+                        'pk': bigtuto.pk,
+                        'slug': bigtuto_draft.slug,
+                        'parent_container_slug': part1.slug,
+                        'container_slug': chapter1.slug
+                    }))
+        self.assertEqual(result.status_code, 404)
+
+        # test access to public
+        self.client.logout()
+        result = self.client.get(
+            reverse('tutorial:view', kwargs={'pk': bigtuto.pk, 'slug': bigtuto_draft.slug}))
+        self.assertEqual(result.status_code, 404)
+
+        result = self.client.get(
+            reverse('tutorial:view-container',
+                    kwargs={
+                        'pk': bigtuto.pk,
+                        'slug': bigtuto_draft.slug,
+                        'container_slug': part1.slug
+                    }))
+        self.assertEqual(result.status_code, 404)
+
+        result = self.client.get(
+            reverse('tutorial:view-container',
+                    kwargs={
+                        'pk': bigtuto.pk,
+                        'slug': bigtuto_draft.slug,
+                        'parent_container_slug': part1.slug,
+                        'container_slug': chapter1.slug
+                    }))
+        self.assertEqual(result.status_code, 404)
+
+        # test access for guest user
+        self.assertEqual(
+            self.client.login(
+                username=self.user_guest.username,
+                password='hostel77'),
+            True)
+
+        result = self.client.get(
+            reverse('tutorial:view', kwargs={'pk': bigtuto.pk, 'slug': bigtuto_draft.slug}))
+        self.assertEqual(result.status_code, 404)
+
+        result = self.client.get(
+            reverse('tutorial:view-container',
+                    kwargs={
+                        'pk': bigtuto.pk,
+                        'slug': bigtuto_draft.slug,
+                        'container_slug': part1.slug
+                    }))
+        self.assertEqual(result.status_code, 404)
+
+        result = self.client.get(
+            reverse('tutorial:view-container',
+                    kwargs={
+                        'pk': bigtuto.pk,
+                        'slug': bigtuto_draft.slug,
+                        'parent_container_slug': part1.slug,
+                        'container_slug': chapter1.slug
+                    }))
+        self.assertEqual(result.status_code, 404)
 
     def tearDown(self):
         if os.path.isdir(settings.ZDS_APP['content']['repo_private_path']):

--- a/zds/tutorialv2/tests/tests_views.py
+++ b/zds/tutorialv2/tests/tests_views.py
@@ -1960,7 +1960,7 @@ class ContentTests(TestCase):
 
         self.assertEqual(PublishableContent.objects.get(pk=midsize_tuto.pk).source, source)  # source is set
 
-        validation = Validation.objects.get(content=midsize_tuto)
+        validation = Validation.objects.filter(content=midsize_tuto).last()
         self.assertIsNotNone(validation)
 
         self.assertEqual(validation.comment_authors, text_validation)
@@ -2032,7 +2032,7 @@ class ContentTests(TestCase):
             follow=False)
         self.assertEqual(result.status_code, 302)
 
-        validation = Validation.objects.get(content=midsize_tuto)
+        validation = Validation.objects.filter(pk=validation.pk).last()
         self.assertEqual(validation.status, 'PENDING_V')
         self.assertEqual(validation.validator, self.user_staff)
 
@@ -2045,7 +2045,7 @@ class ContentTests(TestCase):
             follow=False)
         self.assertEqual(result.status_code, 302)
 
-        validation = Validation.objects.get(content=midsize_tuto)
+        validation = Validation.objects.filter(pk=validation.pk).last()
         self.assertEqual(validation.status, 'PENDING')
         self.assertEqual(validation.validator, None)
 
@@ -2058,7 +2058,7 @@ class ContentTests(TestCase):
             follow=False)
         self.assertEqual(result.status_code, 302)
 
-        validation = Validation.objects.get(content=midsize_tuto)
+        validation = Validation.objects.filter(pk=validation.pk).last()
         self.assertEqual(validation.status, 'PENDING_V')
         self.assertEqual(validation.validator, self.user_staff)
 
@@ -2078,8 +2078,8 @@ class ContentTests(TestCase):
         self.assertEqual(result.status_code, 302)
         self.assertEqual(Validation.objects.count(), 1)
 
-        # ... Therefore, the validation object is in pending status again
-        validation = Validation.objects.get(content=midsize_tuto)
+        # ... Therefore, a new Validation object is created
+        validation = Validation.objects.filter(content=midsize_tuto).last()
         self.assertEqual(validation.status, 'PENDING')
         self.assertEqual(validation.validator, None)
         self.assertEqual(validation.version, midsize_tuto_draft.current_version)
@@ -2098,7 +2098,7 @@ class ContentTests(TestCase):
             follow=False)
         self.assertEqual(result.status_code, 302)
 
-        validation = Validation.objects.get(content=midsize_tuto)
+        validation = Validation.objects.filter(pk=validation.pk).last()
         self.assertEqual(validation.status, 'PENDING_V')
         self.assertEqual(validation.validator, self.user_staff)
 
@@ -2136,7 +2136,7 @@ class ContentTests(TestCase):
             follow=False)
         self.assertEqual(result.status_code, 302)
 
-        validation = Validation.objects.get(content=midsize_tuto)
+        validation = Validation.objects.filter(pk=validation.pk).last()
         self.assertEqual(validation.status, 'REJECT')
         self.assertEqual(validation.comment_validator, text_reject)
 
@@ -2170,7 +2170,7 @@ class ContentTests(TestCase):
             follow=False)
         self.assertEqual(result.status_code, 302)
 
-        validation = Validation.objects.filter(content=midsize_tuto).last()
+        validation = Validation.objects.filter(pk=validation.pk).last()
         self.assertEqual(validation.status, 'PENDING_V')
         self.assertEqual(validation.validator, self.user_staff)
         self.assertEqual(validation.version, midsize_tuto_draft.current_version)
@@ -2186,7 +2186,7 @@ class ContentTests(TestCase):
             follow=False)
         self.assertEqual(result.status_code, 302)
 
-        validation = Validation.objects.filter(content=midsize_tuto).last()
+        validation = Validation.objects.filter(pk=validation.pk).last()
         self.assertEqual(validation.status, 'ACCEPT')
         self.assertEqual(validation.comment_validator, text_accept)
 
@@ -2236,7 +2236,7 @@ class ContentTests(TestCase):
             follow=False)
         self.assertEqual(result.status_code, 302)
 
-        validation = Validation.objects.filter(content=midsize_tuto).last()
+        validation = Validation.objects.filter(pk=validation.pk).last()
         self.assertEqual(validation.status, 'PENDING')
 
         self.assertIsNotNone(PublishableContent.objects.get(pk=midsize_tuto.pk).sha_validation)

--- a/zds/tutorialv2/urls/__init__.py
+++ b/zds/tutorialv2/urls/__init__.py
@@ -3,4 +3,6 @@
 from django.conf.urls import patterns, include, url
 
 urlpatterns = patterns('',
-                       url(r'^contenus/', include('zds.tutorialv2.urls.urls_contents', namespace='content')))
+                       url(r'^contenus/', include('zds.tutorialv2.urls.urls_contents', namespace='content')),
+                       url(r'^tutoriels2/', include('zds.tutorialv2.urls.urls_tutorials', namespace='tutorial')),
+                       url(r'^articles2/', include('zds.tutorialv2.urls.urls_articles', namespace='article')))

--- a/zds/tutorialv2/urls/urls_articles.py
+++ b/zds/tutorialv2/urls/urls_articles.py
@@ -2,13 +2,16 @@
 
 from django.conf.urls import patterns, url
 
-from zds.tutorialv2.views import ListArticles
+from zds.tutorialv2.views import ListArticles, DisplayOnlineArticle
 from zds.tutorialv2.feeds import LastArticlesFeedRSS, LastArticlesFeedATOM
 
 urlpatterns = patterns('',
-                       # Viewing
+                       # Flux
                        url(r'^flux/rss/$', LastArticlesFeedRSS(), name='feed-rss'),
                        url(r'^flux/atom/$', LastArticlesFeedATOM(), name='feed-atom'),
+
+                       # View
+                       url(r'^(?P<pk>\d+)/(?P<slug>.+)/$', DisplayOnlineArticle.as_view(), name='view'),
 
                        # Listing
                        url(r'^$', ListArticles.as_view(), name='list'))

--- a/zds/tutorialv2/urls/urls_articles.py
+++ b/zds/tutorialv2/urls/urls_articles.py
@@ -1,0 +1,14 @@
+# coding: utf-8
+
+from django.conf.urls import patterns, url
+
+from zds.tutorialv2.views import ListArticles
+from zds.tutorialv2.feeds import LastArticlesFeedRSS, LastArticlesFeedATOM
+
+urlpatterns = patterns('',
+                       # Viewing
+                       url(r'^flux/rss/$', LastArticlesFeedRSS(), name='feed-rss'),
+                       url(r'^flux/atom/$', LastArticlesFeedATOM(), name='feed-atom'),
+
+                       # Listing
+                       url(r'^$', ListArticles.as_view(), name='list'))

--- a/zds/tutorialv2/urls/urls_contents.py
+++ b/zds/tutorialv2/urls/urls_contents.py
@@ -6,7 +6,8 @@ from zds.tutorialv2.views import ListContents, DisplayContent, CreateContent, Ed
     CreateContainer, DisplayContainer, EditContainer, CreateExtract, EditExtract, DeleteContainerOrExtract, \
     ManageBetaContent, DisplayHistory, DisplayDiff, ValidationListView, ActivateJSFiddleInContent, \
     AskValidationForContent, ReserveValidation, HistoryOfValidationDisplay, MoveChild, DownloadContent, \
-    UpdateContentWithArchive, CreateContentFromArchive, RedirectContentSEO, AcceptValidation, RejectValidation
+    UpdateContentWithArchive, CreateContentFromArchive, RedirectContentSEO, AcceptValidation, RejectValidation, \
+    RevokeValidation
 
 urlpatterns = patterns('',
                        url(r'^$', ListContents.as_view(), name='index'),
@@ -111,6 +112,9 @@ urlpatterns = patterns('',
                            name="reject-validation"),
                        url(r'^valider/accepter/(?P<pk>\d+)/$', AcceptValidation.as_view(),
                            name="accept-validation"),
+
+                       url(r'^valider/depublier/(?P<pk>\d+)/(?P<slug>.+)/$', RevokeValidation.as_view(),
+                           name="revoke-validation"),
 
                        url(r'^valider/liste/$', ValidationListView.as_view(), name="list-validation"),
 

--- a/zds/tutorialv2/urls/urls_contents.py
+++ b/zds/tutorialv2/urls/urls_contents.py
@@ -6,7 +6,7 @@ from zds.tutorialv2.views import ListContent, DisplayContent, CreateContent, Edi
     CreateContainer, DisplayContainer, EditContainer, CreateExtract, EditExtract, DeleteContainerOrExtract, \
     ManageBetaContent, DisplayHistory, DisplayDiff, ValidationListView, ActivateJSFiddleInContent, \
     AskValidationForContent, ReserveValidation, HistoryOfValidationDisplay, MoveChild, DownloadContent, \
-    UpdateContentWithArchive, CreateContentFromArchive, RedirectContentSEO
+    UpdateContentWithArchive, CreateContentFromArchive, RedirectContentSEO, AcceptValidation
 
 urlpatterns = patterns('',
                        url(r'^$', ListContent.as_view(), name='index'),
@@ -101,12 +101,15 @@ urlpatterns = patterns('',
                        # validation
                        url(r'^valider/proposer/(?P<pk>\d+)/(?P<slug>.+)/$', AskValidationForContent.as_view(),
                            name="ask-validation"),
+                       url(r'^valider/historique/(?P<pk>\d+)/(?P<slug>.+)/$', HistoryOfValidationDisplay.as_view(),
+                           name="history-validation"),
+
                        url(r'^valider/reserver/(?P<pk>\d+)/$', ReserveValidation.as_view(),
                            name="reserve-validation"),
+                       url(r'^valider/accepter/(?P<pk>\d+)/$', AcceptValidation.as_view(),
+                           name="accept-validation"),
 
                        url(r'^valider/liste/$', ValidationListView.as_view(), name="list_validation"),
-                       url(r'^validation/historique/(?P<pk>\d+)/(?P<slug>.+)/$', HistoryOfValidationDisplay.as_view(),
-                           name="history-validation"),
 
                        url(r'^(?P<pk>\d+)/(?P<slug>.+)/(?P<p2>\d+)/'
                            r'(?P<parent_container_slug>.+)/(?P<p3>\d+)/(?P<container_slug>.+)/$',

--- a/zds/tutorialv2/urls/urls_contents.py
+++ b/zds/tutorialv2/urls/urls_contents.py
@@ -6,7 +6,7 @@ from zds.tutorialv2.views import ListContents, DisplayContent, CreateContent, Ed
     CreateContainer, DisplayContainer, EditContainer, CreateExtract, EditExtract, DeleteContainerOrExtract, \
     ManageBetaContent, DisplayHistory, DisplayDiff, ValidationListView, ActivateJSFiddleInContent, \
     AskValidationForContent, ReserveValidation, HistoryOfValidationDisplay, MoveChild, DownloadContent, \
-    UpdateContentWithArchive, CreateContentFromArchive, RedirectContentSEO, AcceptValidation
+    UpdateContentWithArchive, CreateContentFromArchive, RedirectContentSEO, AcceptValidation, RejectValidation
 
 urlpatterns = patterns('',
                        url(r'^$', ListContents.as_view(), name='index'),
@@ -107,10 +107,12 @@ urlpatterns = patterns('',
 
                        url(r'^valider/reserver/(?P<pk>\d+)/$', ReserveValidation.as_view(),
                            name="reserve-validation"),
+                       url(r'^valider/refuser/(?P<pk>\d+)/$', RejectValidation.as_view(),
+                           name="reject-validation"),
                        url(r'^valider/accepter/(?P<pk>\d+)/$', AcceptValidation.as_view(),
                            name="accept-validation"),
 
-                       url(r'^valider/liste/$', ValidationListView.as_view(), name="list_validation"),
+                       url(r'^valider/liste/$', ValidationListView.as_view(), name="list-validation"),
 
                        url(r'^(?P<pk>\d+)/(?P<slug>.+)/(?P<p2>\d+)/'
                            r'(?P<parent_container_slug>.+)/(?P<p3>\d+)/(?P<container_slug>.+)/$',

--- a/zds/tutorialv2/urls/urls_contents.py
+++ b/zds/tutorialv2/urls/urls_contents.py
@@ -2,14 +2,14 @@
 
 from django.conf.urls import patterns, url
 
-from zds.tutorialv2.views import ListContent, DisplayContent, CreateContent, EditContent, DeleteContent,\
+from zds.tutorialv2.views import ListContents, DisplayContent, CreateContent, EditContent, DeleteContent,\
     CreateContainer, DisplayContainer, EditContainer, CreateExtract, EditExtract, DeleteContainerOrExtract, \
     ManageBetaContent, DisplayHistory, DisplayDiff, ValidationListView, ActivateJSFiddleInContent, \
     AskValidationForContent, ReserveValidation, HistoryOfValidationDisplay, MoveChild, DownloadContent, \
     UpdateContentWithArchive, CreateContentFromArchive, RedirectContentSEO, AcceptValidation
 
 urlpatterns = patterns('',
-                       url(r'^$', ListContent.as_view(), name='index'),
+                       url(r'^$', ListContents.as_view(), name='index'),
 
                        # view:
                        url(r'^(?P<pk>\d+)/(?P<slug>.+)/(?P<parent_container_slug>.+)/(?P<container_slug>.+)/$',

--- a/zds/tutorialv2/urls/urls_contents.py
+++ b/zds/tutorialv2/urls/urls_contents.py
@@ -99,6 +99,7 @@ urlpatterns = patterns('',
                        url(r'^importer/(?P<pk>\d+)/(?P<slug>.+)/$', UpdateContentWithArchive.as_view(), name="import"),
 
                        # validation
+                       # TODO: maybe move that in a `urls_validations.py` and give another namespace ?
                        url(r'^valider/proposer/(?P<pk>\d+)/(?P<slug>.+)/$', AskValidationForContent.as_view(),
                            name="ask-validation"),
                        url(r'^valider/historique/(?P<pk>\d+)/(?P<slug>.+)/$', HistoryOfValidationDisplay.as_view(),

--- a/zds/tutorialv2/urls/urls_contents.py
+++ b/zds/tutorialv2/urls/urls_contents.py
@@ -101,11 +101,12 @@ urlpatterns = patterns('',
                        # validation
                        url(r'^valider/proposer/(?P<pk>\d+)/(?P<slug>.+)/$', AskValidationForContent.as_view(),
                            name="ask-validation"),
+                       url(r'^valider/reserver/(?P<pk>\d+)/$', ReserveValidation.as_view(),
+                           name="reserve-validation"),
 
                        url(r'^valider/liste/$', ValidationListView.as_view(), name="list_validation"),
-                       url(r'^valider/reserver/(?P<pk>\d+)/$', ReserveValidation.as_view(), name="reserve_validation"),
-                       url(r'^validation/historique/(?P<pk>\d+)/$', HistoryOfValidationDisplay.as_view(),
-                           name="validation_history"),
+                       url(r'^validation/historique/(?P<pk>\d+)/(?P<slug>.+)/$', HistoryOfValidationDisplay.as_view(),
+                           name="history-validation"),
 
                        url(r'^(?P<pk>\d+)/(?P<slug>.+)/(?P<p2>\d+)/'
                            r'(?P<parent_container_slug>.+)/(?P<p3>\d+)/(?P<container_slug>.+)/$',

--- a/zds/tutorialv2/urls/urls_tutorials.py
+++ b/zds/tutorialv2/urls/urls_tutorials.py
@@ -1,0 +1,14 @@
+# coding: utf-8
+
+from django.conf.urls import patterns, url
+
+from zds.tutorialv2.views import ListTutorials
+from zds.tutorialv2.feeds import LastTutorialsFeedRSS, LastTutorialsFeedATOM
+
+urlpatterns = patterns('',
+                       # Viewing
+                       url(r'^flux/rss/$', LastTutorialsFeedRSS(), name='feed-rss'),
+                       url(r'^flux/atom/$', LastTutorialsFeedATOM(), name='feed-atom'),
+
+                       # Listing
+                       url(r'^$', ListTutorials.as_view(), name='list'))

--- a/zds/tutorialv2/urls/urls_tutorials.py
+++ b/zds/tutorialv2/urls/urls_tutorials.py
@@ -2,13 +2,23 @@
 
 from django.conf.urls import patterns, url
 
-from zds.tutorialv2.views import ListTutorials
+from zds.tutorialv2.views import ListTutorials, DisplayOnlineTutorial, DisplayOnlineContainer
 from zds.tutorialv2.feeds import LastTutorialsFeedRSS, LastTutorialsFeedATOM
 
 urlpatterns = patterns('',
-                       # Viewing
+                       # flux
                        url(r'^flux/rss/$', LastTutorialsFeedRSS(), name='feed-rss'),
                        url(r'^flux/atom/$', LastTutorialsFeedATOM(), name='feed-atom'),
+
+                       # view
+                       url(r'^(?P<pk>\d+)/(?P<slug>.+)/(?P<parent_container_slug>.+)/(?P<container_slug>.+)/$',
+                           DisplayOnlineContainer.as_view(),
+                           name='view-container'),
+                       url(r'^(?P<pk>\d+)/(?P<slug>.+)/(?P<container_slug>.+)/$',
+                           DisplayOnlineContainer.as_view(),
+                           name='view-container'),
+
+                       url(r'^(?P<pk>\d+)/(?P<slug>.+)/$', DisplayOnlineTutorial.as_view(), name='view'),
 
                        # Listing
                        url(r'^$', ListTutorials.as_view(), name='list'))

--- a/zds/tutorialv2/utils.py
+++ b/zds/tutorialv2/utils.py
@@ -234,7 +234,7 @@ class FailureDuringPublication(Exception):
         super(FailureDuringPublication, self).__init__(*args, **kwargs)
 
 
-def publish_content(db_object, versioned):
+def publish_content(db_object, versioned, is_major_update=True):
     """Publish a given content.
 
     Note: create a manifest.json without the introduction and conclusion if not needed. Also remove the "text" field
@@ -244,6 +244,8 @@ def publish_content(db_object, versioned):
     :type db_object: PublishableContent
     :param versioned: version of the content to publish
     :type versioned: VersionedContent
+    :param is_major_update: if set to `True`, will update the publication date
+    :type is_major_update: bool
     :raise FailureDuringPublication: if something goes wrong
     :return: the published representation
     :rtype: PublishedContent
@@ -345,7 +347,9 @@ def publish_content(db_object, versioned):
     versioned.dump_json(os.path.join(repo_path, 'manifest.json'))
 
     # save public version
-    public_version.publication_date = datetime.now()
+    if is_major_update:
+        public_version.publication_date = datetime.now()
+
     public_version.sha_public = versioned.current_version
     public_version.save()
 

--- a/zds/tutorialv2/utils.py
+++ b/zds/tutorialv2/utils.py
@@ -354,3 +354,31 @@ def publish_content(db_object, versioned, is_major_update=True):
     public_version.save()
 
     return public_version
+
+
+def unpublish_content(db_object):
+    """Remove the given content from the public view
+
+    :param db_object: Database representation of the content
+    :type db_object: PublishableContent
+    :return; `True` if unpublished, `False otherwise`
+    """
+
+    try:
+        public_version = PublishedContent.objects.get(content=db_object)
+
+        # clean files
+        old_path = public_version.get_prod_path()
+
+        if os.path.exists(old_path):
+            shutil.rmtree(old_path)
+
+        # remove public_version:
+        public_version.delete()
+
+        return True
+
+    except (ObjectDoesNotExist, IOError):
+        pass
+
+    return False

--- a/zds/tutorialv2/views.py
+++ b/zds/tutorialv2/views.py
@@ -32,7 +32,7 @@ from django.conf import settings
 from django.contrib import messages
 from django.contrib.auth.decorators import login_required, permission_required
 from django.contrib.auth.models import User
-from django.core.exceptions import PermissionDenied, ObjectDoesNotExist
+from django.core.exceptions import PermissionDenied
 from django.core.files import File
 from django.core.urlresolvers import reverse
 from django.db import transaction
@@ -1377,9 +1377,9 @@ class RejectValidation(LoginRequiredMixin, PermissionRequiredMixin, FormView):
 
         user = self.request.user
 
-        try:
-            validation = Validation.objects.filter(pk=self.kwargs['pk']).last()
-        except ObjectDoesNotExist:
+        validation = Validation.objects.filter(pk=self.kwargs['pk']).last()
+
+        if not validation:
             raise PermissionDenied
 
         if validation.validator != user:
@@ -1439,6 +1439,9 @@ class AcceptValidation(LoginRequiredMixin, PermissionRequiredMixin, FormView):
 
         user = self.request.user
         validation = form.validation
+
+        if not validation:
+            raise PermissionDenied
 
         if validation.validator != user:
             raise PermissionDenied
@@ -1524,11 +1527,11 @@ class RevokeValidation(LoginRequiredMixin, PermissionRequiredMixin, SingleConten
         if form.cleaned_data['version'] != self.object.sha_public:
             raise PermissionDenied
 
-        try:
-            validation = Validation.objects.filter(
-                content=self.object,
-                version=self.object.sha_public).latest("date_proposition")
-        except ObjectDoesNotExist:
+        validation = Validation.objects.filter(
+            content=self.object,
+            version=self.object.sha_public).latest("date_proposition")
+
+        if not validation:
             raise PermissionDenied
 
         unpublish_content(self.object)

--- a/zds/tutorialv2/views.py
+++ b/zds/tutorialv2/views.py
@@ -34,7 +34,6 @@ from django.contrib.auth.decorators import login_required, permission_required
 from django.contrib.auth.models import User
 from django.core.exceptions import PermissionDenied
 from django.core.files import File
-from django.core.paginator import Paginator, PageNotAnInteger, EmptyPage
 from django.core.urlresolvers import reverse
 from django.db import transaction
 from django.db.models import Q, Count
@@ -48,7 +47,7 @@ from zds.tutorialv2.forms import ContentForm, ContainerForm, ExtractForm, NoteFo
     AcceptContentForm, RejectForm, JsFiddleActivationForm, ImportContentForm, ImportNewContentForm
 from models import PublishableContent, Container, Validation, ContentReaction, init_new_repo, get_content_from_json, \
     BadManifestError, Extract, default_slug_pool, PublishedContent
-from utils import never_read, mark_read, search_container_or_404, search_extract_or_404
+from utils import search_container_or_404, search_extract_or_404
 from zds.gallery.models import Gallery, UserGallery, Image
 from zds.member.decorator import can_write_and_read_now, LoginRequiredMixin, LoggedWithReadWriteHability
 from zds.member.views import get_client_ip
@@ -56,14 +55,13 @@ from zds.utils import slugify
 from zds.utils.models import Alert
 from zds.utils.models import CommentLike, CommentDislike, SubCategory, HelpWriting, CategorySubCategory
 from zds.utils.mps import send_mp
-from zds.utils.paginator import paginator_range
 from zds.utils.templatetags.emarkdown import emarkdown
 from zds.utils.tutorials import get_blob, export_tutorial_to_md
 from django.utils.translation import ugettext as _
 from django.views.generic import ListView, FormView, DeleteView, RedirectView
 from zds.member.decorator import PermissionRequiredMixin
 from zds.tutorialv2.mixins import SingleContentViewMixin, SingleContentPostMixin, SingleContentFormViewMixin, \
-    SingleContentDetailViewMixin, SingleContentDownloadViewMixin
+    SingleContentDetailViewMixin, SingleContentDownloadViewMixin, SingleOnlineContentDetailViewMixin, ContentTypeMixin
 from git import GitCommandError
 from zds.tutorialv2.utils import publish_content, FailureDuringPublication
 
@@ -229,6 +227,41 @@ class DisplayContent(LoginRequiredMixin, SingleContentDetailViewMixin):
         self.get_forms(context)
 
         return context
+
+
+class DisplayOnlineContent(SingleOnlineContentDetailViewMixin):
+    """Base class that can show any online content"""
+
+    model = PublishedContent
+    template_name = 'tutorialv2/view/content_online.html'
+
+    content_type = ""
+    verbose_type_name = _(u'contenu')
+    verbose_type_name_plural = _(u'contenus')
+
+    def get_context_data(self, **kwargs):
+        """Show the given tutorial if exists."""
+        context = super(DisplayOnlineContent, self).get_context_data(**kwargs)
+
+        # TODO: deal with messaging and stuff like this !!
+
+        return context
+
+
+class DisplayOnlineArticle(DisplayOnlineContent):
+    """Displays the list of published articles"""
+
+    content_type = "ARTICLE"
+    verbose_type_name = _(u'article')
+    verbose_type_name_plural = _(u'articles')
+
+
+class DisplayOnlineTutorial(DisplayOnlineContent):
+    """Displays the list of published tutorials"""
+
+    content_type = "TUTORIAL"
+    verbose_type_name = _(u'tutoriel')
+    verbose_type_name_plural = _(u'tutoriels')
 
 
 class EditContent(LoggedWithReadWriteHability, SingleContentFormViewMixin):
@@ -679,11 +712,43 @@ class DisplayContainer(LoginRequiredMixin, SingleContentDetailViewMixin):
         context = super(DisplayContainer, self).get_context_data(**kwargs)
         context['container'] = search_container_or_404(context['content'], self.kwargs)
         context['containers_target'] = get_target_tagged_tree(context['container'], context['content'])
+
         # pagination: search for `previous` and `next`, if available
         if context['content'].type != 'ARTICLE' and not context['content'].has_extracts():
             chapters = context['content'].get_list_of_chapters()
             try:
                 position = chapters.index(context['container'])
+            except ValueError:
+                pass  # this is not (yet?) a chapter
+            else:
+                context['has_pagination'] = True
+                context['previous'] = None
+                context['next'] = None
+                if position > 0:
+                    context['previous'] = chapters[position - 1]
+                if position < len(chapters) - 1:
+                    context['next'] = chapters[position + 1]
+
+        return context
+
+
+class DisplayOnlineContainer(SingleOnlineContentDetailViewMixin):
+    """Base class that can show any content in any state"""
+
+    template_name = 'tutorialv2/view/container_online.html'
+    content_type = "TUTORIAL"  # obviously, an article cannot have container !
+
+    def get_context_data(self, **kwargs):
+        context = super(DisplayOnlineContainer, self).get_context_data(**kwargs)
+        container = search_container_or_404(self.versioned_object, self.kwargs)
+
+        context['container'] = container
+
+        # pagination: search for `previous` and `next`, if available
+        if not self.versioned_object.has_extracts():
+            chapters = self.versioned_object.get_list_of_chapters()
+            try:
+                position = chapters.index(container)
             except ValueError:
                 pass  # this is not (yet?) a chapter
             else:
@@ -1001,17 +1066,13 @@ class ManageBetaContent(LoggedWithReadWriteHability, SingleContentFormViewMixin)
         return super(ManageBetaContent, self).form_valid(form)
 
 
-class ListOnlineContents(ListView):
+class ListOnlineContents(ContentTypeMixin, ListView):
     """Displays the list of published contents"""
 
     context_object_name = 'public_contents'
     paginate_by = settings.ZDS_APP['content']['content_per_page']
     template_name = 'tutorialv2/index_online.html'
     tag = None
-
-    content_type = ""
-    verbose_type_name = _(u'contenu')
-    verbose_type_name_plural = _(u'contenus')
 
     def top_categories(self):
         """Get all the categories and their related subcategories associated with existing contents.
@@ -1067,9 +1128,6 @@ class ListOnlineContents(ListView):
         context = super(ListOnlineContents, self).get_context_data(**kwargs)
 
         context['tag'] = self.tag
-        context['content_type'] = self.content_type
-        context['verbose_type_name'] = self.verbose_type_name
-        context['verbose_type_name_plural'] = self.verbose_type_name_plural
         context['top_categories'] = self.top_categories()
 
         return context
@@ -1079,16 +1137,12 @@ class ListArticles(ListOnlineContents):
     """Displays the list of published articles"""
 
     content_type = "ARTICLE"
-    verbose_type_name = _(u'article')
-    verbose_type_name_plural = _(u'articles')
 
 
 class ListTutorials(ListOnlineContents):
     """Displays the list of published tutorials"""
 
     content_type = "TUTORIAL"
-    verbose_type_name = _(u'tutoriel')
-    verbose_type_name_plural = _(u'tutoriels')
 
 
 class TutorialWithHelp(ListTutorials):
@@ -1119,119 +1173,6 @@ class TutorialWithHelp(ListTutorials):
 
 
 # TODO ArticleWithHelp
-
-
-class DisplayOnlineContent(DisplayContent):
-    """Display online tutorial"""
-    type = "TUTORIAL"
-    template_name = "tutorial/view_online.html"
-    is_public = True
-
-    def get_forms(self, context, content):
-
-        # Build form to send a note for the current tutorial.
-        context['form'] = NoteForm(content, self.request.user)
-
-    def compatibility_parts(self, content, repo, sha, dictionary, cpt_p):
-        dictionary["tutorial"] = content
-        dictionary["path"] = content.get_repo_path()
-        dictionary["slug"] = slugify(dictionary["title"])
-        dictionary["position_in_tutorial"] = cpt_p
-
-        cpt_c = 1
-        for chapter in dictionary["chapters"]:
-            chapter["part"] = dictionary
-            chapter["slug"] = slugify(chapter["title"])
-            chapter["position_in_part"] = cpt_c
-            chapter["position_in_tutorial"] = cpt_c * cpt_p
-            self.compatibility_chapter(content, repo, sha, chapter)
-            cpt_c += 1
-
-    def compatibility_chapter(self, content, repo, sha, dictionary):
-        """enable compatibility with old version of mini tutorial and chapter implementations"""
-        dictionary["path"] = content.get_prod_path()
-        dictionary["type"] = self.type
-        dictionary["pk"] = Container.objects.get(parent=content).pk  # TODO : find better name
-        dictionary["intro"] = open(os.path.join(content.get_prod_path(), "introduction.md" + ".html"), "r")
-        dictionary["conclu"] = open(os.path.join(content.get_prod_path(), "conclusion.md" + ".html"), "r")
-        # load extracts
-        cpt = 1
-        for ext in dictionary["extracts"]:
-            ext["position_in_chapter"] = cpt
-            ext["path"] = content.get_prod_path()
-            text = open(os.path.join(content.get_prod_path(), ext["text"] + ".html"), "r")
-            ext["txt"] = text.read()
-            cpt += 1
-
-    def get_context_data(self, **kwargs):
-        content = self.get_object()
-        if self.must_redirect:
-            return redirect(content.get_absolute_url_online())
-        # If the tutorial isn't online, we raise 404 error.
-        if not content.in_public():
-            raise Http404
-        self.sha = content.sha_public
-        context = super(DisplayOnlineContent, self).get_context_data(**kwargs)
-
-        context["tutorial"]["update"] = content.update
-        context["tutorial"]["get_note_count"] = content.get_note_count()
-
-        if self.request.user.is_authenticated():
-            # If the user is authenticated, he may want to tell the world how cool the content is
-            # We check if he can post a not or not with
-            # antispam filter.
-            context['tutorial']['antispam'] = content.antispam()
-
-            # If the user has never read this before, we mark this tutorial read.
-            if never_read(content):
-                mark_read(content)
-
-        # Find all notes of the tutorial.
-
-        notes = ContentReaction.objects.filter(related_content__pk=content.pk).order_by("position").all()
-
-        # Retrieve pk of the last note. If there aren't notes for the tutorial, we
-        # initialize this last note at 0.
-
-        last_note_pk = 0
-        if content.last_note:
-            last_note_pk = content.last_note.pk
-
-        # Handle pagination
-
-        paginator = Paginator(notes, settings.ZDS_APP['forum']['posts_per_page'])
-        try:
-            page_nbr = int(self.request.GET.get("page"))
-        except KeyError:
-            page_nbr = 1
-        except ValueError:
-            raise Http404
-
-        try:
-            notes = paginator.page(page_nbr)
-        except PageNotAnInteger:
-            notes = paginator.page(1)
-        except EmptyPage:
-            raise Http404
-
-        res = []
-        if page_nbr != 1:
-            # Show the last note of the previous page
-
-            last_page = paginator.page(page_nbr - 1).object_list
-            last_note = last_page[len(last_page) - 1]
-            res.append(last_note)
-        for note in notes:
-            res.append(note)
-
-        context['notes'] = res
-        context['last_note_pk'] = last_note_pk
-        context['pages'] = paginator_range(page_nbr, paginator.num_pages)
-        context['nb'] = page_nbr
-
-
-class DisplayOnlineArticle(DisplayOnlineContent):
-    type = "ARTICLE"
 
 
 # Staff actions.
@@ -1466,9 +1407,10 @@ class AcceptValidation(LoginRequiredMixin, PermissionRequiredMixin, FormView):
 
             # TODO: send PM and stuff !
             # TODO: handle minor/major version (!?) → just update `pubdate` or not
+            # TODO: deal with other kind of publications (HTML, PDF, archive, ...)
 
             messages.success(self.request, _(u'Le contenu a bien été validé.'))
-            self.success_url = published.get_absolute_url_public()
+            self.success_url = published.get_absolute_url_online()
 
         return super(AcceptValidation, self).form_valid(form)
 

--- a/zds/utils/forums.py
+++ b/zds/utils/forums.py
@@ -12,6 +12,7 @@ def create_topic(
         title,
         subtitle,
         text,
+        key=None,
         related_publishable_content=None):
     """create topic in forum"""
 
@@ -24,6 +25,7 @@ def create_topic(
     n_topic.subtitle = subtitle
     n_topic.pubdate = datetime.now()
     n_topic.author = author
+    n_topic.key = key
 
     n_topic.save()
     if related_publishable_content is not None:

--- a/zds/utils/tutorials.py
+++ b/zds/utils/tutorials.py
@@ -187,7 +187,7 @@ def export_tutorial_to_md(tutorial, sha=None):
         cpt_p = 1
         for part in parts:
             part['tutorial'] = tutorial
-            part['path'] = tutorial.get_repo_path()
+            part['path'] = tutorial.get_path()
             part['slug'] = slugify(part['title'])
             part['position_in_tutorial'] = cpt_p
             intro = open(
@@ -208,7 +208,7 @@ def export_tutorial_to_md(tutorial, sha=None):
             cpt_c = 1
             for chapter in part['chapters']:
                 chapter['part'] = part
-                chapter['path'] = tutorial.get_repo_path()
+                chapter['path'] = tutorial.get_path()
                 chapter['slug'] = slugify(chapter['title'])
                 chapter['type'] = 'BIG'
                 chapter['position_in_part'] = cpt_c
@@ -230,7 +230,7 @@ def export_tutorial_to_md(tutorial, sha=None):
                 for ext in chapter['extracts']:
                     ext['chapter'] = chapter
                     ext['position_in_chapter'] = cpt_e
-                    ext['path'] = tutorial.get_repo_path()
+                    ext['path'] = tutorial.get_path()
                     text = open(
                         os.path.join(
                             tutorial.get_prod_path(sha),

--- a/zds/utils/tutorialv2.py
+++ b/zds/utils/tutorialv2.py
@@ -11,7 +11,10 @@ def export_extract(extract):
     dct['object'] = 'extract'
     dct['slug'] = extract.slug
     dct['title'] = extract.title
-    dct['text'] = extract.get_path(True)
+
+    if extract.text:
+        dct['text'] = extract.get_path(True)
+
     return dct
 
 
@@ -25,8 +28,13 @@ def export_container(container):
     dct['object'] = "container"
     dct['slug'] = container.slug
     dct['title'] = container.title
-    dct['introduction'] = container.introduction
-    dct['conclusion'] = container.conclusion
+
+    if container.introduction:
+        dct['introduction'] = container.introduction
+
+    if container.conclusion:
+        dct['conclusion'] = container.conclusion
+
     dct['children'] = []
 
     if container.has_sub_containers():


### PR DESCRIPTION
**Putain**, je suis enfin arrivé au bout !
# Ce que fait cette PR
- Tout les cas de validations sont implémentés (aka réservation, rejet, publication, dépublication, plus les cas bonus)
- La publication est fonctionnelle
- La liste des articles/tuto est accessible, aux adresses `/tutoriels2/` et `/articles2/`
- Article et tutoriaux publiés sont accessibles, y compris les parties et chapitres
- Tout les points précédents sont couverts par les T.U. qui vont bien (évidement, dans des cas "évident", donc QA _is welcome_).
# Ce que ne fait pas cette PR

(par manque de temps/envie/motivation/chips)
- Pas moyen de commenter un contenu publié pour le moment (trop trop long à faire, pas eu le courage)
- Pas de gestion des "autres trucs" que génère une publication (PDF, HTML, archive, ...). D'ailleurs, le lien "archive" est un piège, parce qu'il renvois la mauvaise version (_aka_ la dernière)
- Pas eu le courage de créer un fichier `urls_validations.py`, alors que je suis quasiment certains que ce serait une bonne idée
- Pas eu le courage non plus de séparer toutes les vues, alors que c'est **le bordel**. J'y pense, ceci dit ;)
- La ZEP-03. Depuis que l'import des fixtures spéciales plantent, je suis coincé. Va falloir que j'aie fixer le problème _upstream_.
- Le café. Grosse déception, je te raconte pas.
- Les flux RSS/ATOM. En fait, c'est sensé fonctionner, mais pareil, y'a un méchant bug de ce coté là a aller fixer _upstream_.
# Comment ça le fait ?

Deux mots d'ordres là derrière : _pas besoin de réinventer la roue_ et _pas d'appel à Git quand on a un contenu publié_. J'aime à penser que c'est ce que j'ai fait, m'enfin je suis ouvert à toutes suggestions.

Bref, deux nouvelles classes font leurs apparitions dans `models.py`: 
- `PublicContent`, qui est un enfant de `VersionedContent` avec un créateur légèrement différent qui fait exprès de pas appeler Git (donc de laisser `repository` à `None`) et de mettre un paramètre `PUBLIC` à `True`. À terme, je me demande si ça va pas me servir à aller foutre un décorateur du genre `@not_in_public` sur les fonctions qui n'ont pas à être appelée en public (aka `repo_*`, `move_*` et tout ça) et qui renverrais une méchante exception.
- `PublishedContent`, qui est le penchant de `PublishableContent`, et qui lui est en base de donnée (**`python manage.py migrate` spotted** !) et qui représente le contenu une fois publié, avec un lien vers le `PublishableContent` correspondant et deux ou trois trucs qui vont avec. J'ai beaucoup hésité avant de rajouter cet object, mais je pense qu'il va simplifier la vie pour deux raisons: 1) il règle de manière simple un problème évident : le `slug` de la version publique est pas forcément celui de la version brouillon (problème récurent actuelement en prod) 2) pour le moment, un seul `PublishedContent` est créé par `PublishableContent`, mais si on joue convenablement avec cette classe, il suffit de garder ceux dont le slug change, et on règle de manière relativement simple notre problème de SEO (je dois encore réfléchir si c'est aussi applicable pour une migration)

Quand à la publication, ce qu'elle fait est assez simple :
1. Pour chaque conteneur, deux possibilités: soit le conteneur possède des extraits pour enfants, et alors, le processus crée un fichier HTML contenant tout les enfants ainsi qu'intro et conclusion. Si cet extrait est consulté, ça ne fait plus qu'un seul fichier à lire. Dans le cas inverse, un fichier est créé pour l'introduction et un pour la conclusion, donc deux fichiers à lire dans le cas de ce genre de conteneur. Je pense que c'est pas grave 
2. Pendant le processus, le `VersionedContent` est altéré pour retirer les infos inutiles: tout les champs `text` des extraits et les champs intro/conclusion des conteneurs dans lesquels le tout à été transformé en un fichier HTML. Je t'invite à aller regarder dans `/public-contents/` pour voir. Le `manifest.json` est ensuite _dumpé_, et il est donc légèrement plus léger et rapide à lire (bon, on parle d'optimisations à l'échelle de la microseconde, mais voilà). Il reste ceci dit nécessaire pour l'affichage d'un contenu publié (sommaire, toussa).
3. Un objet `PublishedContent` est bien sagement créé s'il n'existait pas avant et les bonnes infos sont placées dedans

Quand à la consultation, y'a un joli _mixin_ (avec un nom imprononçable) qui fait le sale boulot, à savoir aller récupérer la version publique (donc un `PublicContent`, donc SANS Git) et aller taper ça dans les variables qui vont bien. Comme un `PublicContent` n'est jamais qu'un `VersionedContent`, le reste se passe de commentaire, puisque c'est les mêmes fonctions au même endroit, moyennant les _templates_ qui vont bien. Et même si on dirait que article et tuto sont séparé, _quepuick_, c'est la même template pour les deux. Je fais dans la factorisation, moi, monsieur !

[Et le temps que j'écrive ma tartine, Travis est passé pour confirmer que j'ai pas fait de bétises](https://travis-ci.org/pierre-24/zds-site/builds/59179188). C'est noël !

Bref. Regarde, commente, merge si tu penses que ça va et _enjoy_. Moi, je vais aller me reposer de ce weekend inteeeeeense en code.
