### PR TITLE
MAJ des templates des 'fiches' de contenus

### DIFF
--- a/templates/tutorialv2/includes/content_item.part.html
+++ b/templates/tutorialv2/includes/content_item.part.html
@@ -12,7 +12,7 @@
     ">
         <img src="{{ content.image.physical.tutorial_illu.url }}" alt="" class="tutorial-img avatar">
         <div class="tutorial-infos">
-            <h3>{{ content.title }}</h3>
+            <h3>{{ content.title }} </h3>
 
             <span class="article-metadata">
                 {% if content.subcategory.all %}

--- a/templates/tutorialv2/includes/content_item_type_article.part.html
+++ b/templates/tutorialv2/includes/content_item_type_article.part.html
@@ -1,0 +1,84 @@
+{% load captureas %}
+{% load thumbnail %}
+{% load date %}
+{% load i18n %}
+
+{% captureas link %}
+    {% if type == 'beta' and article.in_beta %}
+        {{ article.get_absolute_url_beta }}
+    {% else %}
+        {{ article.get_absolute_url }}
+    {% endif %}
+{% endcaptureas %}
+
+{# Authors (by X, Y and Z) ; can't have multiple whitespaces because of the title ! #}
+{% captureas authors_text %}
+    {% for author in article.authors.all %}{% if forloop.first %}{% trans "par" %}{% elif forloop.last %} {% trans "et" %}{% else %},{% endif %} {% if author == user %}{% trans "vous" %}{% else %}{{ author.username }}{% endif %}{% endfor %}
+{% endcaptureas %}
+
+<article class="content-item article-item has-reactions">
+    <a href="{{ link }}" tabindex="-1" class="content-illu">
+        {% if article.image %}
+            <img src="{{ article.image.content_thumb.url }}" alt="">
+        {% endif %}
+    </a>
+
+    <div class="content-info">
+        <a href="{{ link }}" title="{{ article.title }}{% if article.description and show_description %} − {{ article.description }}{% endif %}">
+            <h3 class="content-title" itemprop="itemListElement">
+                {{ article.title }}
+            </h3>
+            
+            <p class="content-description">
+                {% if article.description and show_description %}
+                    {{ article.description }}
+                {% endif %}
+            </p>
+
+            <div class="content-meta">
+                {% if article.pubdate %}
+                    <time class="content-pubdate" pubdate="{{ article.pubdate|date:"c" }}">
+                        {{ article.pubdate|format_date|capfirst }}
+                    </time>
+                {% endif %}
+
+                {% if article.sha_public %}
+                    <p class="content-authors">
+                        {{ authors_text }}
+                    </p>
+                {% elif article.sha_validation %}
+                    <p class="content-state">
+                        {% trans "En validation" %}
+                    </p>
+                {% else %}
+                    <p class="content-state">
+                        {% trans "Brouillon" %}
+                    </p>
+                {% endif %}
+            </div>
+        </a>
+
+        <a class="content-reactions" href="
+            {% if article.last_note %}
+                {{ article.last_read_note }}
+            {% else %}
+                {{ link }}#reactions
+            {% endif %}"
+            title="{% if article.get_note_count == 0 %}{% trans "Aucune" %}{% else %}{{ article.get_note_count }}{% endif %} {% trans "réaction" %}{{ article.get_note_count|pluralize }}"
+        >
+            <span>{{ article.get_note_count }}</span>
+        </a>
+    </div>
+
+    {% if article.subcategory.all %}
+        <ul class="content-tags" itemprop="keywords">
+            {% for category in article.subcategory.all|slice:":3" %}
+                <li>
+                  <a href="{% url "zds.article.views.index" %}?tag={{ category.slug }}">
+                    {{ category.title }}
+                  </a>
+                </li>
+            {% endfor %}
+        </ul>
+    {% endif %}
+</article>

--- a/templates/tutorialv2/includes/content_item_type_tutoriel.part.html
+++ b/templates/tutorialv2/includes/content_item_type_tutoriel.part.html
@@ -1,0 +1,66 @@
+{% load captureas %}
+{% load thumbnail %}
+{% load date %}
+{% load i18n %}
+
+{% captureas link %}
+    {% if type == 'beta' and tutorial.in_beta %}
+        {{ tutorial.get_absolute_url_beta }}
+    {% else %}
+        {{ tutorial.get_absolute_url }}
+    {% endif %}
+{% endcaptureas %}
+
+{# Authors (by X, Y and Z) ; can't have multiple whitespaces because of the title ! #}
+{% captureas authors_text %}
+    {% for author in tutorial.authors.all %}{% if forloop.first %}{% trans "par" %}{% elif forloop.last %} {% trans "et" %}{% else %},{% endif %} {% if author == user %}{% trans "vous" %}{% else %}{{ author.username }}{% endif %}{% endfor %}
+{% endcaptureas %}
+
+{# Categories (in X, Y and Z) #}
+{% captureas categories_text %}
+    {% for category in tutorial.subcategory.all %}{% if forloop.first %}{% trans "dans" %}{% elif forloop.last %}{% trans "et" %}{% else %},{% endif %} {{ category.title }}{% endfor %}
+{% endcaptureas %}
+
+<article class="content-item expand-description tutorial-item{{ item_class }}">
+    <a href="{{ link }}" title="{{ tutorial.title }}{% if tutorial.description and show_description %} − {{ tutorial.description }}{% endif %}">
+        <div class="content-illu">
+            {% if tutorial.image %}
+                <img src="{{ tutorial.image.physical.content_thumb.url }}" alt="">
+            {% endif %}
+        </div>
+        
+        <div class="content-info">
+            <h3 class="content-title" itemprop="itemListElement">
+                {{ tutorial.title }}
+            </h3>
+
+            <p class="content-description">
+                {% if tutorial.description and show_description %}
+                    {{ tutorial.description }}
+                {% endif %}
+            </p>
+
+            <div class="content-meta" title="{% trans "Publié" %} {{ tutorial.pubdate|format_date }} {{ categories_text }} {{ authors_text }}">
+                {% if tutorial.subcategory %}
+                    <p class="content-categories">
+                        {{ categories_text }}
+                    </p>
+                {% endif %}
+
+                {% if tutorial.authors %}
+                    <p class="content-authors">
+                        {{ authors_text }}
+                    </p>
+                {% endif %}
+
+                {% if tutorial.pubdate %}
+                    <time class="content-pubdate" pubdate="{{ tutorial.pubdate|date:"c" }}">
+                        -
+                        <span class="long">{{ tutorial.pubdate|format_date|capfirst }}</span>
+                        <span class="short">{{ tutorial.pubdate|format_date:True|capfirst }}</span>
+                    </time>
+                {% endif %}
+            </div>
+        </div>
+    </a>
+</article>

--- a/templates/tutorialv2/index.html
+++ b/templates/tutorialv2/index.html
@@ -47,21 +47,32 @@
         {% include "misc/paginator.html" with position="top" %}
 
         {% if contents != None %}
+            <h3>Mes tutoriels</h3>
             <div class="tutorial-list clearfix">
                 {% for content in contents %}
-                    {% include "tutorialv2/includes/content_item.part.html" %}
+                    {% if content.type == "TUTORIAL" %}
+                        {% include "tutorialv2/includes/content_item_type_tutoriel.part.html" with tutorial=content %}
+                    {% endif %}
+                {% endfor %}
+            </div>
+            <h3>Mes articles</h3>
+            <div class="tutorial-list clearfix">
+                {% for content in contents %}
+                    {% if content.type == "ARTICLE" %}
+                        {% include "tutorialv2/includes/content_item_type_article.part.html" with article=content %}
+                    {% endif %}
                 {% endfor %}
             </div>
         {% elif tutorials != None %}
             <div class="tutorial-list clearfix">
                 {% for tutorial in tutorials %}
-                    {% include "tutorialv2/includes/content_item.part.html" with content=tutorial %}
+                    {% include "tutorialv2/includes/content_item_type_tutoriel.part.html" with tutorial=content %}
                 {% endfor %}
             </div>
         {% elif articles != None %}
             <div class="tutorial-list clearfix">
                 {% for article in articles %}
-                    {% include "tutorialv2/includes/content_item.part.html" with content=article %}
+                    {% include "tutorialv2/includes/content_item_type_article.part.html" with article=content %}
                 {% endfor %}
             </div>
         {% endif %}


### PR DESCRIPTION
Ticket https://github.com/artragis/zds-site/issues/99

La PR permettant d'afficher les "fiches" de contenus sur les pages contenus/ , contenus/articles ou contenus/tutoriels.

J'ai divise cela en deux "sous-templates" respectant la nomenclature `content_item_type_<letype>.part.html`.

Le code est inspire de ce qui a ete fait pour la ZEP-4 avec les derniers fixs et quelques ajustements. Cependant je ne touche qu'au template, pas au CSS donc certains trucs peuvent etre encore un peu bancal (il faudra un rebase du CSS de la ZEP-4 pour constater que tout va bien)
