### PR TITLE
MAJ les droits pour afficher la validation de contenu pour les staff

### DIFF
--- a/fixtures/users.yaml
+++ b/fixtures/users.yaml
@@ -15,6 +15,7 @@
             - 76
             - 109
             - 121
+            - 184
 -   model: auth.group
     pk: 2
     fields:

--- a/templates/base.html
+++ b/templates/base.html
@@ -447,13 +447,13 @@
                                             <a href="{% url "update-member" %}">{% trans "Paramètres" %}</a>
                                         </li>
 
-                                        {% if is_staff %}
+                                        {% if perms.tutorialv2.change_tutorialv2 %}
                                             <li>
                                                 <a href="{% url "validation:list" %}?type=tuto">{% trans "Validation des tutoriels" %}</a>
                                             </li>
                                         {% endif %}
 
-                                        {% if perms.article.change_article %}
+                                        {% if perms.tutorialv2.change_tutorialv2 %}
                                             <li>
                                                 <a href="{% url "validation:list" %}?type=article">{% trans "Validation des articles" %}</a>
                                             </li>

--- a/templates/tutorialv2/comment/new.html
+++ b/templates/tutorialv2/comment/new.html
@@ -63,7 +63,7 @@
                 {% url "content:down-vote" %}?message={{ message.pk }}
             {% endcaptureas %}
 
-            {% include "tutorialv2/includes/reaction_message.part.html" with perms_change=perms.tutorial.change_tutorial topic=object %}
+            {% include "tutorialv2/includes/reaction_message.part.html" with perms_change=perms.tutorialv2.change_tutorialv2 topic=object %}
         {% endfor %}
     </div>
 

--- a/templates/tutorialv2/view/content_online.html
+++ b/templates/tutorialv2/view/content_online.html
@@ -143,7 +143,7 @@
 
     {% include "misc/paginator.html" with position="top" topic=content is_online=True anchor="comments" %}
 
-    {% set perms.tutorial.change_tutorial as perms_change %}
+    {% set perms.tutorialv2.change_tutorialv2 as perms_change %}
     {% for message in reactions %}
 
         {% captureas edit_link %}

--- a/zds/tutorialv2/mixins.py
+++ b/zds/tutorialv2/mixins.py
@@ -75,7 +75,7 @@ class SingleContentViewMixin(object):
             raise Http404
 
         # check permissions:
-        self.is_staff = self.request.user.has_perm('tutorial.change_tutorial')
+        self.is_staff = self.request.user.has_perm('tutorialv2.change_tutorialv2')
         self.is_author = self.request.user in obj.authors.all()
 
         if self.must_be_author and not self.is_author:
@@ -331,7 +331,7 @@ class SingleOnlineContentViewMixin(ContentTypeMixin):
                 raise Http404  # should only happen if the content is unpublished
 
         self.is_author = self.request.user in obj.content.authors.all()
-        self.is_staff = self.request.user.has_perm('tutorial.change_tutorial')
+        self.is_staff = self.request.user.has_perm('tutorialv2.change_tutorialv2')
 
         return obj
 

--- a/zds/tutorialv2/views/views_contents.py
+++ b/zds/tutorialv2/views/views_contents.py
@@ -1472,7 +1472,7 @@ class ContentOfAuthor(ZdSPagingListView):
         context['filters'] = []
         context['sort'] = self.sort.lower()
         context['filter'] = self.filter.lower()
-        context['is_staff'] = self.request.user.has_perm('tutorial.change_tutorial')
+        context['is_staff'] = self.request.user.has_perm('tutorialv2.change_tutorialv2')
         context['usr'] = self.user
         for sort in self.sorts.keys():
             context['sorts'].append({'key': sort, 'text': self.sorts[sort][1]})

--- a/zds/tutorialv2/views/views_validations.py
+++ b/zds/tutorialv2/views/views_validations.py
@@ -98,7 +98,7 @@ class AskValidationForContent(LoggedWithReadWriteHability, SingleContentFormView
 
         # test if admin or author
         """"if not self.request.user in self.object.authors.all() \
-                and not self.request.user.has_perm('tutorial.change_tutorial'):
+                and not self.request.user.has_perm('tutorialv2.change_tutorialv2'):
             raise PermissionDenied"""
 
         old_validation = Validation.objects.filter(
@@ -183,7 +183,7 @@ class CancelValidation(LoginRequiredMixin, ModalFormView):
         if validation.status not in ['PENDING', 'PENDING_V']:
             raise PermissionDenied  # cannot cancel a validation that is already accepted or rejected
 
-        if user not in validation.content.authors.all() and not user.has_perms('tutorial.change_tutorial'):
+        if user not in validation.content.authors.all() and not user.has_perm('tutorialv2.change_tutorialv2'):
             raise PermissionDenied
 
         versioned = validation.content.load_version(sha=validation.version)


### PR DESCRIPTION
#116

Cette PR remet d'aplomb la gestion des droits pour les staff afin que ces derniers puissent voir la page de validation pour tout types de contenu (article/tutos) dans la sidebar.

Si vous ne rechargez pas les fixtures, pensez a ajouter les droits manuellement via l'interface d'admin:

![screenshot from 2015-05-19 11 34 04](https://cloud.githubusercontent.com/assets/761168/7700134/caa7c97c-fe1c-11e4-9e3a-4ac07fdaa0ab.png)
