### PR TITLE
Sépare le texte d'un article en extraits (sections)

### DIFF
--- a/fixtures/advanced/articles.yaml
+++ b/fixtures/advanced/articles.yaml
@@ -1,0 +1,10 @@
+-   factory: zds.article.factories.PublishedArticleFactory
+    fields:
+        title: "Article court"
+        authors: [3]
+        light: True
+-   factory: zds.article.factories.PublishedArticleFactory
+    fields:
+        title: "Article long"
+        authors: [1,3]
+        light: False

--- a/zds/article/factories.py
+++ b/zds/article/factories.py
@@ -37,7 +37,15 @@ class ArticleFactory(factory.DjangoModelFactory):
     @classmethod
     def _prepare(cls, create, **kwargs):
         light = kwargs.pop('light', False)
+
+        authors = []
+        if "authors" in kwargs:
+            authors = kwargs.pop("authors")
+
         article = super(ArticleFactory, cls)._prepare(create, **kwargs)
+
+        for auth in authors:
+            article.authors.add(auth)
 
         path = article.get_path()
         if not os.path.isdir(path):

--- a/zds/article/factories.py
+++ b/zds/article/factories.py
@@ -13,6 +13,19 @@ from zds.article.views import mep
 from zds.utils.models import SubCategory
 
 
+content_light = u'Un test'
+
+content_long = u'Une introduction\n\n' \
+               u'# Un extrait\n\n' \
+               u'Le contenu de l\'extrait\n\n' \
+               u'# Un second extrait\n\n' \
+               u'Toujours du contenu !!!\n\n' \
+               u'```\n' \
+               u'# Un piège\n' \
+               u'```\n\n' \
+               u'Et encore un peu de texte'
+
+
 class ArticleFactory(factory.DjangoModelFactory):
     FACTORY_FOR = Article
 
@@ -23,6 +36,7 @@ class ArticleFactory(factory.DjangoModelFactory):
 
     @classmethod
     def _prepare(cls, create, **kwargs):
+        light = kwargs.pop('light', False)
         article = super(ArticleFactory, cls)._prepare(create, **kwargs)
 
         path = article.get_path()
@@ -37,7 +51,12 @@ class ArticleFactory(factory.DjangoModelFactory):
         f.write(json_writer.dumps(man, indent=4, ensure_ascii=False).encode('utf-8'))
         f.close()
         f = open(os.path.join(path, article.text), "w")
-        f.write(u'Test')
+
+        if light:
+            f.write(content_light.encode('utf-8'))
+        else:
+            f.write(content_long.encode('utf-8'))
+
         f.close()
         repo.index.add(['manifest.json', article.text])
         cm = repo.index.commit("Init Article")

--- a/zds/article/factories.py
+++ b/zds/article/factories.py
@@ -11,6 +11,7 @@ from zds.article.models import Article, Reaction, \
 from zds.utils.articles import export_article
 from zds.article.views import mep
 from zds.utils.models import SubCategory
+from zds.member.models import User
 
 
 content_light = u'Un test'
@@ -45,7 +46,7 @@ class ArticleFactory(factory.DjangoModelFactory):
         article = super(ArticleFactory, cls)._prepare(create, **kwargs)
 
         for auth in authors:
-            article.authors.add(auth)
+            article.authors.add(User.objects.get(pk=auth))
 
         path = article.get_path()
         if not os.path.isdir(path):

--- a/zds/tutorialv2/factories.py
+++ b/zds/tutorialv2/factories.py
@@ -45,8 +45,10 @@ class PublishableContentFactory(factory.DjangoModelFactory):
             auths = kwargs.pop("author_list")
 
         publishable_content = super(PublishableContentFactory, cls)._prepare(create, **kwargs)
+
         for auth in auths:
             publishable_content.authors.add(auth)
+
         publishable_content.gallery = GalleryFactory()
         for author in publishable_content.authors.all():
             UserGalleryFactory(user=author, gallery=publishable_content.gallery)

--- a/zds/tutorialv2/management/commands/migrate_to_zep12.py
+++ b/zds/tutorialv2/management/commands/migrate_to_zep12.py
@@ -120,6 +120,63 @@ def create_gallery_for_article(content):
     return gal
 
 
+def split_article_in_extracts(article):
+    """Split a text into extracts according to titles (create a new extract if level 1, remove a level otherwise)
+
+    Note that this function generate no commit
+
+    :param article: An article
+    :type article: VersionedContent
+    """
+
+    txt = article.children[0].get_text()
+    article.children[0].repo_delete(do_commit=False)  # remove old extract
+
+    extracts = []
+
+    extract_text = ''
+    extract_title = ''
+    in_code = False
+
+    # split
+    for line in txt.split('\n'):
+        if line[:3] == '```':
+            in_code = not in_code
+
+        if not in_code and line[0] == '#':
+            title_level = 0
+
+            for a in line:
+                if a != '#':
+                    break
+                else:
+                    title_level += 1
+
+            title_content = line[title_level:].strip()  # get text right after the `#`
+
+            if title_level == 1 and title_content != '':
+                extracts.append((extract_title, extract_text))
+                extract_title = title_content
+                extract_text = u''
+            else:
+                line = ''.join(['#' for i in range(title_level-1)]) + ' ' + title_content
+                extract_text += line + '\n'
+
+        else:
+            extract_text += line + '\n'
+
+    # add last
+    extracts.append((extract_title, extract_text))
+
+    # create extracts
+    for num, definition in enumerate(extracts):
+        title, text = definition
+        if num == 0:
+            article.repo_update(article.title, text, '', do_commit=False)
+        else:
+            article.repo_add_extract(title, text, do_commit=False)
+
+
 def migrate_articles():
     articles = Article.objects.all()
     if len(articles) == 0:
@@ -168,6 +225,8 @@ def migrate_articles():
 
         if exported.licence:
             versioned.licence = exported.licence
+
+        split_article_in_extracts(versioned)  # create extracts from text
 
         versioned.dump_json()
         exported.sha_draft = versioned.commit_changes(u"Migration version 2")

--- a/zds/tutorialv2/management/commands/migrate_to_zep12.py
+++ b/zds/tutorialv2/management/commands/migrate_to_zep12.py
@@ -143,7 +143,7 @@ def split_article_in_extracts(article):
         if line[:3] == '```':
             in_code = not in_code
 
-        if not in_code and line[0] == '#':
+        if not len(line) == 0 and not in_code and line[0] == '#':
             title_level = 0
 
             for a in line:
@@ -159,7 +159,7 @@ def split_article_in_extracts(article):
                 extract_title = title_content
                 extract_text = u''
             else:
-                line = ''.join(['#' for i in range(title_level-1)]) + ' ' + title_content
+                line = ''.join(['#' for i in range(title_level - 1)]) + ' ' + title_content
                 extract_text += line + '\n'
 
         else:
@@ -252,9 +252,9 @@ def migrate_articles():
             map_previous.save()
 
             # publish the article !
-            published = publish_content(exported, exported.load_version(current.sha_public), False)
+            published = publish_content(exported, exported.load_version(exported.sha_draft), False)
             exported.pubdate = current.pubdate
-            exported.sha_public = current.sha_public
+            exported.sha_public = exported.sha_draft
             exported.public_version = published
             exported.save()
             published.content_public_slug = current.slug


### PR DESCRIPTION
Suggestion faite dans #145 : le texte d'un article est séparé en extraits à l'aide des titres de niveau 1. Tout ce qui vient avant le premier titre est placé dans le champ `introduction`. Tout les autres titres sont remontés d'un niveau.

QA dans #171, donc à merger quand Travis a donné son accord.

Est ce qu'il faut un TU ?
