### PR TITLE
Corrige l'intégration des images

### DIFF
--- a/zds/tutorialv2/tests/tests_utils.py
+++ b/zds/tutorialv2/tests/tests_utils.py
@@ -334,7 +334,7 @@ class UtilsTests(TestCase):
             # JPEG:
             ('http://upload.wikimedia.org/wikipedia/commons/6/6b/01Aso.jpg', '01Aso.jpg'),
             # Image which does not exists:
-            ('http://test.com/test.png', 'test.png'),
+            ('http://test.com/test idiot.png', 'test_idiot.png'),  # NOTE: space changed into `_` !
             # SVG (will be converted to png):
             ('http://upload.wikimedia.org/wikipedia/commons/f/f9/10DF.svg', '10DF.png'),
             # GIF (will be converted to png):

--- a/zds/tutorialv2/tests/tests_views.py
+++ b/zds/tutorialv2/tests/tests_views.py
@@ -1629,7 +1629,7 @@ class ContentTests(TestCase):
         # check links:
         text = versioned.children[0].get_text()
         for img in Image.objects.filter(gallery=new_article.gallery).all():
-            self.assertTrue('![]({})'.format(img.get_absolute_url()) in text)
+            self.assertTrue('![]({})'.format(settings.ZDS_APP['site']['url'] + img.physical.url) in text)
 
         # import into first article (that will only change the images)
         result = self.client.post(
@@ -1656,7 +1656,7 @@ class ContentTests(TestCase):
         # check links:
         text = versioned.children[0].get_text()
         for img in Image.objects.filter(gallery=new_version.gallery).all():
-            self.assertTrue('![]({})'.format(img.get_absolute_url()) in text)
+            self.assertTrue('![]({})'.format(settings.ZDS_APP['site']['url'] + img.physical.url) in text)
 
         # clean up
         os.remove(draft_zip_path)

--- a/zds/tutorialv2/utils.py
+++ b/zds/tutorialv2/utils.py
@@ -283,16 +283,16 @@ def retrieve_image(url, directory):
         img_extension = ''
         img_filename = img_basename
 
-    new_url = os.path.join('images', img_basename)
-    new_url_as_png = os.path.join('images', img_filename + '.png')
+    new_url = os.path.join('images', img_basename.replace(' ', '_'))
+    new_url_as_png = os.path.join('images', img_filename.replace(' ', '_') + '.png')
 
     store_path = os.path.abspath(os.path.join(directory, new_url))  # destination
 
     if img_basename == '' or os.path.exists(store_path) or os.path.exists(os.path.join(directory, new_url_as_png)):
         # another image with the same name already exists (but assume the two are different)
         img_filename += "_" + str(datetime.now().microsecond)
-        new_url = os.path.join('images', img_filename + '.' + img_extension)
-        new_url_as_png = os.path.join('images', img_filename + '.png')
+        new_url = os.path.join('images', img_filename.replace(' ', '_') + '.' + img_extension)
+        new_url_as_png = os.path.join('images', img_filename.replace(' ', '_') + '.png')
         store_path = os.path.abspath(os.path.join(directory, new_url))
 
     try:
@@ -300,6 +300,10 @@ def retrieve_image(url, directory):
                 or parsed_url.netloc[:3] == "www" or parsed_url.path[:3] == "www":
             urlretrieve(url, store_path)  # download online image
         else:  # it's a local image, coming from a gallery
+
+            if url[0] == '/':  # because `os.path.join()` think it's an absolute path if it start with `/`
+                url = url[1:]
+
             source_path = os.path.join(settings.BASE_DIR, url)
             if os.path.isfile(source_path):
                 shutil.copy(source_path, store_path)

--- a/zds/tutorialv2/views/views_contents.py
+++ b/zds/tutorialv2/views/views_contents.py
@@ -549,7 +549,7 @@ class UpdateContentWithArchive(LoggedWithReadWriteHability, SingleContentFormVie
             pic.pubdate = datetime.now()
             pic.save()
 
-            translation_dic[image_path] = pic.get_absolute_url()
+            translation_dic[image_path] = settings.ZDS_APP['site']['url'] + pic.physical.url
 
             # finally, remove image
             if os.path.exists(temp_image_path):


### PR DESCRIPTION
Corrections de deux erreurs (une grosse et une petite)
- Utilisation d'un lien absolu pour l'import d'archive (cause un bug lors de la publication, tous les chemins vers les images étaient considérées comme chemin absolu à la racine, d'ou carré noir de _failback_ systématique)
- Remplacement des espaces par des `_` lors de l'import des images en publication pour le PDF (parce que ça cause un problème aussi lors de la publication)
