### PR TITLE
Correction #221: L'archive publique contient bien la dernière version.

### DIFF
--- a/zds/tutorialv2/utils.py
+++ b/zds/tutorialv2/utils.py
@@ -617,6 +617,10 @@ def publish_content(db_object, versioned, is_major_update=True):
     else:
         public_version = PublishedContent()
 
+    # change sha1 version
+    db_object.sha_public = versioned.current_version
+    db_object.save()
+
     # make the new public version
     public_version.content_public_slug = versioned.slug
     public_version.content_type = versioned.type


### PR DESCRIPTION
| Q | R |
| --- | --- |
| Correction de bugs ? | oui |
| Nouvelle Fonctionnalité ? | non |
| Tickets (_issues_) concernés | https://github.com/artragis/zds-site/issues/221 |

Le hashage de la version publique du PublishableContent pointait vers l'avant dernière version et non la dernière. Lors du chargement de [publishable.load_version(None, True)](https://github.com/artragis/zds-site/blob/zep_12_double_stack/zds/tutorialv2/utils.py#L656), l'avant dernière version était charge et non la dernière. Ainsi dans l'archive apparaissait l'avant dernière version et non la dernière.

**Je sais pas qu'elle conséquence cela peut avoir, tu peux regarder Artragis ?**

**QA**:

_Étape 1:_
- Créé un contenu avec une description et aucune partie et publier le.
- Changer la description et le titre et ajouter une partie, publier le.
- Télécharger l'archive de la version publié, vérifier que le manifest correspond à la version publiée.

_Étape 2:_
- Créé un contenu avec une description et aucune partie.
- Télécharger l'archive et vérifier que le manifest correspond
