### PR TITLE
Personnalise plus les pages listant les articles et tutoriels

### DIFF
--- a/templates/tutorialv2/index.html
+++ b/templates/tutorialv2/index.html
@@ -81,12 +81,15 @@
 
 
 {% block sidebar_new %}
-    <a href="{% url "content:create-tutorial" %}" class="new-btn ico-after more blue">
-        {% trans "Nouveau tutoriel" %}
-    </a>
-     <a href="{% url "content:create-article" %}" class="new-btn ico-after more blue">
-        {% trans "Nouvel article" %}
-    </a>
+    {% if tutorials != None %}
+        <a href="{% url "content:create-tutorial" %}" class="new-btn ico-after more blue">
+            {% trans "Nouveau tutoriel" %}
+        </a>
+    {% elif articles != None %}
+        <a href="{% url "content:create-article" %}" class="new-btn ico-after more blue">
+            {% trans "Nouvel article" %}
+        </a>
+    {% endif %}
 
     <a href="{% url "content:import-new" %}" class="new-btn ico-after import blue">
         {% trans "Importer un nouveau contenu" %}

--- a/templates/tutorialv2/index_online.html
+++ b/templates/tutorialv2/index_online.html
@@ -79,16 +79,23 @@
 
 {% block sidebar %}
     <aside class="sidebar accordeon mobile-menu-bloc" data-title="{% trans "Catégories des" %} {{ verbose_type_name_plural }}">
-        <a href="{% url "content:create-tutorial" %}" class="new-btn ico-after more blue">
-            {% trans "Nouveau tutoriel" %}
-        </a>
-         <a href="{% url "content:create-article" %}" class="new-btn ico-after more blue">
-            {% trans "Nouvel article" %}
-        </a>
+        {% if current_content_type == "TUTORIAL" %}
+            <a href="{% url "content:create-tutorial" %}" class="new-btn ico-after more blue">
+                {% trans "Nouveau tutoriel" %}
+            </a>
 
-        <a href="{% url "content:helps" %}" class="new-btn ico-after help blue">
-            {% trans "Aider les auteurs" %}
-        </a>
+            <a href="{% url 'content:helps' %}?type=tuto" class="new-btn ico-after help blue">
+                {% trans "Aider les auteurs" %}
+            </a>
+        {% elif current_content_type == "ARTICLE" %}
+            <a href="{% url "content:create-article" %}" class="new-btn ico-after more blue">
+                {% trans "Nouvel article" %}
+            </a>
+
+            <a href="{% url 'content:helps' %}?type=article" class="new-btn ico-after help blue">
+                {% trans "Aider les auteurs" %}
+            </a>
+        {% endif %}
 
         <h3>{% blocktrans %} Catégories <span class="wide">des {{ verbose_type_name_plural }}</span> {% endblocktrans %}</h3>
 


### PR DESCRIPTION
Voilà une petite PR qui personnalise un peu les pages lisant les articles et tutoriels.

Là où avant on avait deux liens "Nouveau tutoriel" et "Nouvel article", on n'en a plus qu'un en fonction de la page sur laquelle on est.

Quand il y a un lien vers la page d'aide aux auteurs, ça filtre les tutoriels ou les articles en en fonction de la page où on est parti.
