### PR TITLE
During zep12 migration, copy image from none directory to galery

### DIFF
--- a/zds/gallery/models.py
+++ b/zds/gallery/models.py
@@ -98,7 +98,7 @@ class Image(models.Model):
     gallery = models.ForeignKey('Gallery', verbose_name=_(u'Galerie'), db_index=True)
     title = models.CharField(_(u'Titre'), max_length=80)
     slug = models.SlugField(max_length=80)
-    physical = ThumbnailerImageField(upload_to=image_path)
+    physical = ThumbnailerImageField(upload_to=image_path, max_length=200)
     legend = models.CharField(_(u'Légende'), max_length=80, null=True, blank=True)
     pubdate = models.DateTimeField(_(u'Date de création'), auto_now_add=True, db_index=True)
     update = models.DateTimeField(_(u'Date de modification'), null=True, blank=True)


### PR DESCRIPTION
Devrait régler les erreurs 400. 

J'ai besoin d'une QA car mon environnement de dev est cassé un peu de partout maintenant.

**QA**:
- Créé une nouvelle base avec Mysql.
- Changer le setting pour que vous utilisez votre nouvelle base
- Retourner sur la branche sur dev.
- `python manage.py migrate`
- Créé deux articles:
  - Le premier changer la miniature dés la création de l'article.
  - Le deuxième mettre aucune miniature, éditer puis rajouter la miniature.
- Changer la branche vers la zep_12_doublestack
- python manage.py migrate
- python manage.py migrate_to_zep12
- Prier votre dieu 
- Vérifier que vous avez bien vos deux images.
