### PR TITLE
Corrige un souci d'affichage dans un formulaire sur mobile

### DIFF
--- a/assets/scss/layout/_content.scss
+++ b/assets/scss/layout/_content.scss
@@ -461,7 +461,7 @@
 }
 
 @media only screen and #{$media-mobile} {
-    .main .content-container .article-content .btn {
+    .main .content-container .article-content .btn-center {
         float: none;
         text-align: center;
     }

--- a/templates/tutorialv2/includes/warn_typo.part.html
+++ b/templates/tutorialv2/includes/warn_typo.part.html
@@ -3,7 +3,7 @@
 
 {% if user.is_authenticated and user not in content.authors.all %}
 
-<a href="#warn-typo-modal" class="open-modal btn btn-grey ico-after edit blue">
+<a href="#warn-typo-modal" class="open-modal btn btn-grey ico-after edit blue btn-center">
     {% trans "Signaler une faute dans" %}
     {% if not container %}
         {% if content.type == 'ARTICLE' %}


### PR DESCRIPTION
Corrige #342.

Vérifier que le souci d'affichage dans le formulaire d'edition d'un message sur mobile est réglé et que le bouton "Signaler une faute" prend toujours toute la largeur sur mobile.
