### PR TITLE
Correction de l'affichage du datepicker

### DIFF
--- a/Gulpfile.js
+++ b/Gulpfile.js
@@ -21,7 +21,7 @@ var sourceDir = "assets",
     vendorsDir = "vendors",
     spriteDir = "sprite",
     stylesFiles = ["main.scss"],
-    vendorsCSS = ["node_modules/normalize.css/normalize.css", "node_modules/pikaday/css/pickaday.css", "node_modules/pikaday/css/theme.css"],
+    vendorsCSS = ["node_modules/normalize.css/normalize.css", "node_modules/pikaday/css/pikaday.css", "node_modules/pikaday/css/theme.css"],
     vendorsJS = ["node_modules/jquery/dist/jquery.js", "node_modules/cookies-eu-banner/dist/cookies-eu-banner.js",
         "node_modules/pikaday/pikaday.js"],
     imageminConfig = { optimizationLevel: 3, progressive: true, interlaced: true };

--- a/assets/scss/main.scss
+++ b/assets/scss/main.scss
@@ -86,3 +86,9 @@
 10. High pixel ratio (retina)
 -------------------------*/
 @import "base/high-pixel-ratio";
+
+/*-------------------------
+11. Pikaday (datepicker)
+-------------------------*/
+@import "vendors/pikaday";
+@import "vendors/theme";


### PR DESCRIPTION
Voilà le petit correctif front comme demandé ! :)

L'affichage ne s'effectuait pas correctement car : 
- les fichiers de style n'étaient pas importés. 
- dans le fichier `Gulpfile.js`, il y avait un `c` de trop dans le nom du fichier.
