### PR TITLE
Améliorations sur la modération des billets

### DIFF
--- a/templates/base.html
+++ b/templates/base.html
@@ -574,7 +574,7 @@
                                                 <a href="{% url "validation:list" %}?type=article">{% trans "Validation des articles" %}</a>
                                             </li>
                                             <li class="staff-only">
-                                                <a href="{% url "validation:list-opinion" %}">{% trans "Validation des billets" %}</a>
+                                                <a href="{% url "validation:list-opinion" %}">{% trans "Choix des billets" %}</a>
                                             </li>
                                         {% endif %}
 

--- a/templates/tutorialv2/messages/validation_unpublish_opinion.md
+++ b/templates/tutorialv2/messages/validation_unpublish_opinion.md
@@ -1,0 +1,9 @@
+{% load i18n %}
+
+{% blocktrans with title=content.title|safe moderator_name=moderator.username|safe moderator_url=moderator.get_absolute_url %}
+
+Votre billet « [{{ title }}]({{ url }}) » a été définitivement dépublié par 
+[{{ moderator_name }}]({{ moderator_url }}), probablement car il enfreignait les CGU du site.
+
+N'hésitez pas à contacter cette personne afin d'obtenir plus d'informations sur sa décision.
+{% endblocktrans %}

--- a/templates/tutorialv2/validation/opinion-moderation-history.html
+++ b/templates/tutorialv2/validation/opinion-moderation-history.html
@@ -3,18 +3,15 @@
 {% load captureas %}
 {% load i18n %}
 
-{% block title_base %}
-    {% trans "Historique de modération du billet." %}
-{% endblock %}
-
 {% block title %}
-    {% trans "Historique de modération du billet." %}
+    {% trans "Historique de modération du billet" %}
 {% endblock %}
 
 
 
 {% block breadcrumb_base %}
-    <li>{% trans "Historique de modération du billet." %}</li>
+    <li><a href="{{ content.get_absolute_url }}">{{ content.title }}</a></li>
+    <li>{% trans "Historique de modération" %}</li>
 {% endblock %}
 
 
@@ -23,8 +20,7 @@
     <section class="full-content-wrapper">
         <h1>
             {% block headline %}
-                {% trans "Historique de modération du billet." %}
-                ({{ contents|length }})
+                {% trans "Historique de modération du billet" %}
             {% endblock %}
         </h1>
 
@@ -33,15 +29,15 @@
         {% endcaptureas %}
 
         {% block content %}
-            {% if contents %}
+            {% if operations %}
                 <table class="fullwidth">
                     <thead>
                         <tr>
                             <th>{% trans "Date" %}</th>
                             <th>{% trans "Modérateur" %}</th>
-                            <th>{% trans "Décision encore active" %}</th>
                             <th>{% trans "Décision prise" %}</th>
-                            <th>{% trans "" %}</th>
+                            <th>{% trans "Décision encore active" %}</th>
+                            <th>{% trans "Révoquer" %}</th>
                         </tr>
                     </thead>
                     <tbody>
@@ -52,6 +48,9 @@
                                 </td>
                                 <td>
                                     {% include 'misc/member_item.part.html' with member=operation.staff_user avatar=True %}
+                                </td>
+                                <td>
+                                    {{ operation.get_operation_display }}
                                 </td>
                                 <td class="state" data-toggle="{% if operation.is_effective %}
                                         {% trans 'Non' %}
@@ -65,11 +64,8 @@
                                     {% endif %}
                                 </td>
                                 <td>
-                                    {{ operation.operation }}
-                                </td>
-                                <td>
                                     <button class="btn btn-grey ico-after hide unpick-action" data-url="{% url 'validation:revoke-ignore-opinion' operation.pk %}">
-                                        {% trans 'Révoquer la décision.' %}
+                                        {% trans 'Révoquer la décision' %}
                                     </button>
                                 </td>
                             </tr>
@@ -78,7 +74,7 @@
                 </table>
             {% else %}
                 <p>
-                    {% trans "Aucun billet" %}
+                    {% trans "Aucune action dans l'historique de modération." %}
                 </p>
             {% endif %}
         {% endblock %}

--- a/templates/tutorialv2/view/content.html
+++ b/templates/tutorialv2/view/content.html
@@ -423,7 +423,15 @@
                     <a href="#valid-publication" class="open-modal ico-after tick green">
                         {% trans "Publier" %}
                     </a>
-                    {% crispy formPublication %}
+                    {% if not is_definitely_unpublished %}
+                        {% crispy formPublication %}
+                    {% else %}
+                        <div id="valid-publication" class="modal modal-flex">
+                            <p>
+                                {% trans "Ce billet a été définitivement dépublié par un modérateur. Il ne peut pas faire l'objet d'une nouvelle publication." %}
+                            </p>
+                        </div>
+                    {% endif %}
                 </li>
             {% endif %}
         {% endif %}

--- a/templates/tutorialv2/view/content.html
+++ b/templates/tutorialv2/view/content.html
@@ -465,6 +465,12 @@
                             {% trans "Historique de validation" %}
                         </a>
                     </li>
+                {% else %}
+                    <li>
+                        <a href="{% url "validation:ignore-opinion" content.pk content.slug %}" class="ico-after history blue">
+                            {% trans "Historique de modération" %}
+                        </a>
+                    </li>
                 {% endif %}
                 <li>
                     <a  href="{% url 'mp-new' %}?{% for username in content.authors.all %}&amp;username={{ username }}{% endfor %}"

--- a/zds/tutorialv2/forms.py
+++ b/zds/tutorialv2/forms.py
@@ -1191,13 +1191,13 @@ class DoNotPickOpinionForm(forms.Form):
 
     def clean(self):
         cleaned = super(DoNotPickOpinionForm, self).clean()
-        cleaned['operation'] = self.data['operation'] if self.data['operation'] in ['NO_PICK', 'REJECT'] else None
+        cleaned['operation'] = self.data['operation'] if self.data['operation'] in ['NO_PICK', 'REJECT', 'REMOVE_PUB'] else None
         return cleaned
 
     def is_valid(self):
         base = super(DoNotPickOpinionForm, self).is_valid()
         if not self['operation']:
-            self._errors['operation'] = _('Opération invalide, NO_PICK ou REJECT attendu.')
+            self._errors['operation'] = _('Opération invalide, NO_PICK, REJECT ou REMOVE_PUB attendu.')
             return False
         return base
 

--- a/zds/tutorialv2/forms.py
+++ b/zds/tutorialv2/forms.py
@@ -1191,7 +1191,8 @@ class DoNotPickOpinionForm(forms.Form):
 
     def clean(self):
         cleaned = super(DoNotPickOpinionForm, self).clean()
-        cleaned['operation'] = self.data['operation'] if self.data['operation'] in ['NO_PICK', 'REJECT', 'REMOVE_PUB'] else None
+        cleaned['operation'] = self.data['operation'] \
+            if self.data['operation'] in ['NO_PICK', 'REJECT', 'REMOVE_PUB'] else None
         return cleaned
 
     def is_valid(self):

--- a/zds/tutorialv2/mixins.py
+++ b/zds/tutorialv2/mixins.py
@@ -261,6 +261,7 @@ class SingleContentDetailViewMixin(SingleContentViewMixin, DetailView):
         context['content'] = self.versioned_object
         context['can_edit'] = self.is_author
         context['is_staff'] = self.is_staff
+        context['is_definitely_unpublished'] = self.object.is_definitely_unpublished()
         if self.sha != self.object.sha_draft:
             context['version'] = self.sha
 

--- a/zds/tutorialv2/models/models_database.py
+++ b/zds/tutorialv2/models/models_database.py
@@ -274,6 +274,11 @@ class PublishableContent(models.Model, TemplatableContentModelMixin):
         """
         return self.in_public() and sha == self.sha_public
 
+    def is_definitely_unpublished(self):
+        """Is this content definitely unpublished by a moderator ?"""
+
+        return PickListOperation.objects.filter(content=self, operation='REMOVE_PUB', is_effective=True).exists()
+
     def load_version_or_404(self, sha=None, public=None):
         """Using git, load a specific version of the content. if `sha` is `None`, the draft/public version is used (if
         `public` is `True`).
@@ -1178,15 +1183,16 @@ class Validation(models.Model):
 @python_2_unicode_compatible
 class PickListOperation(models.Model):
     class Meta:
-        verbose_name = 'Choix des Billets'
-        verbose_name_plural = 'Choix des Billets'
+        verbose_name = "Choix d'un billet"
+        verbose_name_plural = 'Choix des billets'
+
     content = models.ForeignKey(PublishableContent, null=False, blank=True,
                                 verbose_name='Contenu proposé', db_index=True)
-    operation = models.CharField(null=False, blank=False, db_index=True, max_length=len('NO_PICK'),
+    operation = models.CharField(null=False, blank=False, db_index=True, max_length=len('REMOVE_PUB'),
                                  choices=PICK_OPERATIONS)
-    operation_date = models.DateTimeField(null=False, db_index=True)
-    version = models.CharField(null=False, blank=False, max_length=128)
-    staff_user = models.ForeignKey(User, null=False, on_delete=CASCADE)
+    operation_date = models.DateTimeField(null=False, db_index=True, verbose_name="Date de l'opération")
+    version = models.CharField(null=False, blank=False, max_length=128, verbose_name='Version du billet concernée')
+    staff_user = models.ForeignKey(User, null=False, on_delete=CASCADE, verbose_name='Modérateur')
     is_effective = models.BooleanField(verbose_name='Choix actif', default=True)
 
     def __str__(self):

--- a/zds/tutorialv2/views/views_validations.py
+++ b/zds/tutorialv2/views/views_validations.py
@@ -667,6 +667,7 @@ class DoNotPickOpinion(PermissionRequiredMixin, NoValidationBeforeFormViewMixin)
         context = super(DoNotPickOpinion, self).get_context_data()
         context['operations'] = PickListOperation.objects\
             .filter(content=self.object)\
+            .order_by('-operation_date')\
             .prefetch_related('staff_user', 'staff_user__profile')
         return context
 

--- a/zds/tutorialv2/views/views_validations.py
+++ b/zds/tutorialv2/views/views_validations.py
@@ -569,6 +569,8 @@ class PublishOpinion(LoggedWithReadWriteHability, NoValidationBeforeFormViewMixi
     def form_valid(self, form):
         # get database representation
         db_object = self.object
+        if self.object.is_definitely_unpublished():
+            raise PermissionDenied
         versioned = self.versioned_object
         self.success_url = versioned.get_absolute_url()
         try:
@@ -664,7 +666,7 @@ class DoNotPickOpinion(PermissionRequiredMixin, NoValidationBeforeFormViewMixin)
     def get_context_data(self):
         context = super(DoNotPickOpinion, self).get_context_data()
         context['operations'] = PickListOperation.objects\
-            .filter(content=self.db_object)\
+            .filter(content=self.object)\
             .prefetch_related('staff_user', 'staff_user__profile')
         return context
 

--- a/zds/tutorialv2/views/views_validations.py
+++ b/zds/tutorialv2/views/views_validations.py
@@ -695,6 +695,26 @@ class DoNotPickOpinion(PermissionRequiredMixin, NoValidationBeforeFormViewMixin)
                 self.object.sha_picked = None
                 self.object.pubdate = None
                 self.object.save()
+
+                # send PM
+                msg = render_to_string(
+                    'tutorialv2/messages/validation_unpublish_opinion.md',
+                    {
+                        'content': versioned,
+                        'url': versioned.get_absolute_url(),
+                        'moderator': self.request.user,
+                    })
+
+                bot = get_object_or_404(User, username=settings.ZDS_APP['member']['bot_account'])
+                send_mp(
+                    bot,
+                    versioned.authors.all(),
+                    _(u'Dépublication'),
+                    versioned.title,
+                    msg,
+                    True,
+                    direct=False
+                )
         except ValueError:
             logger.exception('Could not %s the opinion %s', form.cleaned_data['operation'], str(self.object))
             return HttpResponse(json.dumps({'result': 'FAIL', 'reason': str(_('Mauvaise opération'))}), status=400)


### PR DESCRIPTION
Hello @artragis 

Je suis parvenu à plusieurs améliorations (même si tout n'est pas parfait). Ce qui est fait :

- `Validation des billets` => `Choix des billets`
- Quelques corrections sur le template d'historique de modération
- Les opérations sont ordonnées correctement dans l'historique de modération.
- `REMOVE_PUB` fonctionne maintenant (plus d'erreur 500).
- Quelques corrections sur le modèle (je n'ai pas généré les migrations)
- Il n'est plus possible de publier un billet définitivement dépublié.
- Un MP est envoyé aux auteurs d'un billet définitivement dépublié.
- Un lien vers l'historique de modération

Ce qu'il faudrait faire :

- La fonction `Révoquer` de l'historique de modération semble boguée. Il faudrait masquer le bouton quand la décision est déjà révoquée et donner un retour visuel quand on clique (genre faire disparaître le bouton + passer à `Non` la colonne `Décision encore active`).
- Comme on l'a vu avec l'exemple de `REMOVE_PUB`, envoyer une requête avec une `operation` non attendue provoque une erreur 500, il faudrait parer à ça (le `is_valid` est-il appelé correctement ?).
- Révoquer le choix d'un billet n'a aucun effet, ça devrait le dé-choisir
- Les tests