### PR TITLE
l'orm django n'aime pas la concurrence

### DIFF
--- a/zds/tutorialv2/management/commands/publication_watchdog.py
+++ b/zds/tutorialv2/management/commands/publication_watchdog.py
@@ -16,7 +16,7 @@ class Command(BaseCommand):
     help = 'Launch a watchdog that generate all exported formats (epub, pdf...) files without blocking request handling'
 
     def handle(self, *args, **options):
-        with ThreadPoolExecutor(5) as executor:
+        with ThreadPoolExecutor(1) as executor:
             try:
                 while True:
                     Command.launch_publicators(executor)


### PR DESCRIPTION
En déployant l'instance ZdS complète en simili-prod, dans une VM debian 10, cappée à 2CPU et 2Go de RAM, j'ai constaté que j'obtenais encore l'erreur "Mysql has gone Away".

Après investigation, je me rends compte que le problème semble venir de la parallelisation de la génération watchdog. Puisque l'erreur survient à chaque vois au niveau de la fonction d'accès à la base de donnée via l'ORM.

En passant le nombre de workers max à 1 au lieu de 5 initialiement, ça se génére bien comme il faut.